### PR TITLE
Typing Annotations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ def build(label, release=false) {
                     export PATH="/usr/local/bin:\${PATH}"
 
                     pip install mypy
-                    mypy clkhash --ignore-missing-imports --strict-optional
+                    mypy clkhash --ignore-missing-imports --no-implicit-optional --disallow-untyped-calls
                 """
               }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,16 @@ def build(label, release=false) {
             def testsError = null
 
             try {
+              stage('Type') {
+              sh """#!/usr/bin/env bash
+                    set -xe
+                    export PATH="/usr/local/bin:\${PATH}"
+
+                    pip install mypy
+                    mypy clkhash --ignore-missing-imports --strict-optional
+                """
+              }
+
               stage('Test') {
 
                 sh """#!/usr/bin/env bash

--- a/README.md
+++ b/README.md
@@ -85,3 +85,10 @@ address.
 ```
 $ TEST_ENTITY_SERVICE= INCLUDE_CLI= python -m nose
 ```
+
+
+# Static Typechecking
+
+```
+$ mypy clkhash --ignore-missing-imports --strict-optional --no-implicit-optional --disallow-untyped-calls
+```

--- a/clkhash/benchmark.py
+++ b/clkhash/benchmark.py
@@ -7,6 +7,7 @@ from clkhash.clk import generate_clk_from_csv
 
 
 def compute_hash_speed(n, quiet=False):
+    # type: (int, bool) -> float
     """
     Hash time.
     """

--- a/clkhash/clk.py
+++ b/clkhash/clk.py
@@ -8,17 +8,23 @@ import logging
 import time
 
 import sys
+from typing import List, Any, Generator, Iterable, TypeVar, TextIO, Tuple, Union
 
 if sys.version_info[0] >= 3:
     import concurrent.futures
 
 from clkhash.bloomfilter import stream_bloom_filters, calculate_bloom_filters, serialize_bitarray
 from clkhash.key_derivation import generate_key_lists
+from clkhash.identifier_types import IdentifierType
 
 log = logging.getLogger('clkhash.clk')
 
 
-def hash_and_serialize_chunk(chunk_pii_data, schema_types, keys):
+def hash_and_serialize_chunk(chunk_pii_data,    # type: Iterable[List[Any]]
+                             schema_types,      # type: Iterable[IdentifierType]
+                             keys               # type: Tuple[Tuple[bytes, ...], Tuple[bytes, ...]]
+                             ):
+    # type: (...) -> List[str]
     """
     Generate Bloom filters (ie hash) from chunks of PII then serialize
     the generated Bloom filters.
@@ -35,7 +41,13 @@ def hash_and_serialize_chunk(chunk_pii_data, schema_types, keys):
     return clk_data
 
 
-def generate_clk_from_csv(input, keys, schema_types, no_header=False, progress_bar=True):
+def generate_clk_from_csv(input,            # type: TextIO
+                          keys,             # type: List[Union[bytes, str]]
+                          schema_types,     # type: List[IdentifierType]
+                          no_header=False,  # type: bool
+                          progress_bar=True # type: bool
+                          ):
+    # type: (...) -> List[str]
     log.info("Hashing data")
 
     # Read from CSV file
@@ -68,6 +80,7 @@ def generate_clk_from_csv(input, keys, schema_types, no_header=False, progress_b
 
 
 def generate_clks(pii_data, schema_types, key_lists, callback=None):
+    # TODO type annotation
     results = []
 
     # Chunks PII
@@ -97,8 +110,11 @@ def generate_clks(pii_data, schema_types, key_lists, callback=None):
                 callback(len(chunk))
     return results
 
+T = TypeVar('T')      # Declare generic type variable
+
 
 def chunks(l, n):
+    # type: (List[T], int) -> Iterable[List[T]]
     """Yield successive n-sized chunks from l."""
     for i in range(0, len(l), n):
         yield l[i:i + n]

--- a/clkhash/clk.py
+++ b/clkhash/clk.py
@@ -8,7 +8,8 @@ import logging
 import time
 
 import sys
-from typing import List, Any, Generator, Iterable, TypeVar, TextIO, Tuple, Union, Sequence
+from typing import List, Any, Generator, Iterable, TypeVar, TextIO, Tuple, Union, Sequence, \
+    Callable, Optional
 
 if sys.version_info[0] >= 3:
     import concurrent.futures
@@ -79,8 +80,12 @@ def generate_clk_from_csv(input,            # type: TextIO
     return results
 
 
-def generate_clks(pii_data, schema_types, key_lists, callback=None):
-    # TODO type annotation
+def generate_clks(pii_data,         # type: Sequence[Tuple[str, ...]]
+                  schema_types,     # type: List[IdentifierType]
+                  key_lists,        # type: Tuple[Tuple[bytes, ...], ...]
+                  callback=None     # type: Optional[Callable[[int], None]]
+                  ):
+    # type: (...) -> List[Any]
     results = []
 
     # Chunks PII

--- a/clkhash/clk.py
+++ b/clkhash/clk.py
@@ -8,7 +8,7 @@ import logging
 import time
 
 import sys
-from typing import List, Any, Generator, Iterable, TypeVar, TextIO, Tuple, Union
+from typing import List, Any, Generator, Iterable, TypeVar, TextIO, Tuple, Union, Sequence
 
 if sys.version_info[0] >= 3:
     import concurrent.futures
@@ -20,7 +20,7 @@ from clkhash.identifier_types import IdentifierType
 log = logging.getLogger('clkhash.clk')
 
 
-def hash_and_serialize_chunk(chunk_pii_data,    # type: Iterable[List[Any]]
+def hash_and_serialize_chunk(chunk_pii_data,    # type: Iterable[Tuple[Any]]
                              schema_types,      # type: Iterable[IdentifierType]
                              keys               # type: Tuple[Tuple[bytes, ...], Tuple[bytes, ...]]
                              ):
@@ -42,7 +42,7 @@ def hash_and_serialize_chunk(chunk_pii_data,    # type: Iterable[List[Any]]
 
 
 def generate_clk_from_csv(input,            # type: TextIO
-                          keys,             # type: List[Union[bytes, str]]
+                          keys,             # type: Tuple[Union[bytes, str], Union[bytes, str]]
                           schema_types,     # type: List[IdentifierType]
                           no_header=False,  # type: bool
                           progress_bar=True # type: bool
@@ -63,7 +63,7 @@ def generate_clk_from_csv(input,            # type: TextIO
     # Read the lines in CSV file and add it to PII
     pii_data = []
     for line in reader:
-        pii_data.append([element.strip() for element in line])
+        pii_data.append(tuple([element.strip() for element in line]))
 
     # generate two keys for each identifier
     key_lists = generate_key_lists(keys, len(schema_types))
@@ -114,7 +114,7 @@ T = TypeVar('T')      # Declare generic type variable
 
 
 def chunks(l, n):
-    # type: (List[T], int) -> Iterable[List[T]]
+    # type: (Sequence[T], int) -> Iterable[Sequence[T]]
     """Yield successive n-sized chunks from l."""
     for i in range(0, len(l), n):
         yield l[i:i + n]

--- a/clkhash/identifier_types.py
+++ b/clkhash/identifier_types.py
@@ -1,7 +1,7 @@
 """
 Convert PII to tokens
 """
-from typing import Dict, List
+from typing import Dict, List, NoReturn, Any, Callable, Union, Optional
 
 from clkhash.tokenizer import unigramlist, bigramlist
 
@@ -15,9 +15,11 @@ class IdentifierType:
     """
 
     def __init__(self, unigram=False, weight=1, **kwargs):
+        # type: (bool, int, Any) -> None
         """
         :param unigram: Use uni-gram instead of using bi-grams
         :param int weight: How many times to include this identifier.
+        :param kwargs: Extra keyword arguments passed to the tokenizer
         Can be set to zero to skip
         """
         self.weight = int(weight)
@@ -28,7 +30,7 @@ class IdentifierType:
         # type: (str) -> List[str]
         result = []
         for i in range(self.weight):
-            for token in self.tokenizer(entry, **self.kwargs):
+            for token in self.tokenizer(entry, **self.kwargs):      # type: ignore
                 result.append(token)
 
         return result
@@ -78,7 +80,7 @@ weighted_types = {
 
 
 def identifier_type_from_description(schema_object):
-    # type: (Dict[str, str]) -> IdentifierType
+    # type: (Dict[str, Any]) -> IdentifierType
     """
     Convert a dictionary describing a feature into an IdentifierType
 

--- a/clkhash/identifier_types.py
+++ b/clkhash/identifier_types.py
@@ -1,6 +1,7 @@
 """
 Convert PII to tokens
 """
+from typing import Dict, List
 
 from clkhash.tokenizer import unigramlist, bigramlist
 
@@ -15,7 +16,6 @@ class IdentifierType:
 
     def __init__(self, unigram=False, weight=1, **kwargs):
         """
-
         :param unigram: Use uni-gram instead of using bi-grams
         :param int weight: How many times to include this identifier.
         Can be set to zero to skip
@@ -25,6 +25,7 @@ class IdentifierType:
         self.kwargs = kwargs
 
     def __call__(self, entry):
+        # type: (str) -> List[str]
         result = []
         for i in range(self.weight):
             for token in self.tokenizer(entry, **self.kwargs):
@@ -77,10 +78,12 @@ weighted_types = {
 
 
 def identifier_type_from_description(schema_object):
+    # type: (Dict[str, str]) -> IdentifierType
     """
-    Given a dict describing a feature, return an Identifier type.
+    Convert a dictionary describing a feature into an IdentifierType
+
     :param schema_object:
-    :return:
+    :return: An IdentifierType
     """
     assert "identifier" in schema_object
     id = schema_object['identifier']
@@ -99,5 +102,3 @@ def identifier_type_from_description(schema_object):
         id_type.weight = schema_object['weight']
 
     return id_type
-
-

--- a/clkhash/key_derivation.py
+++ b/clkhash/key_derivation.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, Union, Optional, Sequence
+from typing import Tuple, Union, Optional, Sequence, Any
 
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
@@ -77,7 +77,7 @@ class HKDFconfig:
 
     @staticmethod
     def check_is_bytes(value):
-        # type: (Union[str, bytes]) -> bytes
+        # type: (Any) -> bytes
         if isinstance(value, bytes):
             return value
         else:
@@ -85,7 +85,7 @@ class HKDFconfig:
 
     @staticmethod
     def check_is_bytes_or_none(value):
-        # type: (Optional[bytes]) -> Optional[bytes]
+        # type: (Any) -> Optional[bytes]
         if value is None:
             return value
         else:

--- a/clkhash/key_derivation.py
+++ b/clkhash/key_derivation.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, Union, Optional
+from typing import Tuple, List, Union, Optional, Sequence
 
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
@@ -14,7 +14,11 @@ DEFAULT_KEY_SIZE = 64
 class HKDFconfig:
     supported_hash_algos = 'SHA256', 'SHA512'
 
-    def __init__(self, master_secret, salt=None, info=None, hash_algo='SHA256'):
+    def __init__(self, master_secret,   # type: bytes
+                 salt=None,             # type: Optional[bytes]
+                 info=None,             # type: Optional[bytes]
+                 hash_algo='SHA256'     # type: str
+                 ):                     # type: (...) -> None
         """
         The parameters for the HDKF are defined as follows:
 
@@ -81,6 +85,7 @@ class HKDFconfig:
 
     @staticmethod
     def check_is_bytes_or_none(value):
+        # type: (Optional[bytes]) -> Optional[bytes]
         if value is None:
             return value
         else:
@@ -113,7 +118,7 @@ def hkdf(hkdf_config, num_keys, key_size=DEFAULT_KEY_SIZE):
     return keys
 
 
-def generate_key_lists(master_secrets,              # type: List[Union[bytes, str]]
+def generate_key_lists(master_secrets,              # type: Sequence[Union[bytes, str]]
                        num_identifier,              # type: int
                        key_size=DEFAULT_KEY_SIZE,   # type: int
                        salt=None,                   # type: Optional[bytes]

--- a/clkhash/randomnames.py
+++ b/clkhash/randomnames.py
@@ -14,7 +14,7 @@ TODO: Add RESTfull api to generate reasonable name data as requested
 from __future__ import print_function
 
 import csv
-from typing import NoReturn, List, Tuple, Iterable
+from typing import List, Tuple, Iterable, TextIO, Union, Dict
 
 import random
 from datetime import datetime, timedelta
@@ -39,7 +39,11 @@ def load_csv_data(resource_name):
         return [row[0] for row in reader]
 
 
-def save_csv(data, schema, file):
+def save_csv(data,      # type: Iterable[Tuple[Union[str, int], ...]]
+             schema,    # type: Iterable[Dict[str, str]]
+             file       # type: TextIO
+             ):
+    # type: (...) -> None
     """
     Output generated data as csv with header.
 

--- a/clkhash/randomnames.py
+++ b/clkhash/randomnames.py
@@ -14,6 +14,8 @@ TODO: Add RESTfull api to generate reasonable name data as requested
 from __future__ import print_function
 
 import csv
+from typing import NoReturn, List, Tuple, Iterable
+
 import random
 from datetime import datetime, timedelta
 import math
@@ -24,12 +26,17 @@ from clkhash.schema import get_schema_types
 
 
 def load_csv_data(resource_name):
+    # type: (str) -> List[str]
     """Loads a specified data file as csv and returns the first column as a Python list
     """
-    data = pkgutil.get_data('clkhash', 'data/{}'.format(resource_name)).decode('utf8')
-    reader = csv.reader(data.splitlines())
-    next(reader, None)  # skip the headers
-    return [row[0] for row in reader]
+    data_bytes = pkgutil.get_data('clkhash', 'data/{}'.format(resource_name))
+    if data_bytes is None:
+        raise ValueError("No data resource found with name {}".format(resource_name))
+    else:
+        data = data_bytes.decode('utf8')
+        reader = csv.reader(data.splitlines())
+        next(reader, None)  # skip the headers
+        return [row[0] for row in reader]
 
 
 def save_csv(data, schema, file):
@@ -47,6 +54,7 @@ def save_csv(data, schema, file):
 
 
 def random_date(start, end):
+    # type: (datetime, datetime) -> datetime
     """
     This function will return a random datetime between two datetime objects.
 
@@ -71,6 +79,7 @@ class NameList:
         ]
 
     def __init__(self, n):
+        # type: (int) -> None
         self.load_names()
 
         self.earliest_birthday = datetime(year=1916, month=1, day=1)
@@ -83,6 +92,7 @@ class NameList:
         return get_schema_types(self.schema)
 
     def generate_random_person(self, n):
+        # type: (int) -> Iterable[Tuple[int, str, str, str]]
         """
         Generator that yields details on a person with plausible name, sex and age.
 
@@ -103,6 +113,7 @@ class NameList:
             )
 
     def load_names(self):
+        # type: () -> None
         """
         This function loads a name database into globals firstNames and lastNames
 

--- a/clkhash/schema.py
+++ b/clkhash/schema.py
@@ -1,11 +1,12 @@
+from typing import List, Dict, Optional, TextIO
 
 import os
-from clkhash.identifier_types import identifier_type_from_description
+from clkhash.identifier_types import IdentifierType, identifier_type_from_description
 
 
 def load_schema(schema_file):
+    # type: (Optional[TextIO]) -> List[Dict[str, str]]
     if schema_file is None:
-        #log("Assuming default schema")
         schema = [
             {"identifier": 'INDEX'},
             {"identifier": 'NAME freetext'},
@@ -14,7 +15,6 @@ def load_schema(schema_file):
         ]
     else:
         filename, extension = os.path.splitext(schema_file.name)
-        #log("Loading schema from {} file".format(extension))
 
         if extension == '.json':
             import json
@@ -25,11 +25,12 @@ def load_schema(schema_file):
         else:
             schema_line = schema_file.read().strip()
             schema = [{"identifier": s.strip()} for s in schema_line.split(",")]
-        #log("{}".format(schema))
 
     return schema
 
+
 def get_schema_types(schema):
+    # type: (List[Dict[str, str]]) -> List[IdentifierType]
     schema_types = [identifier_type_from_description(column) for column in schema]
     return schema_types
 

--- a/clkhash/tokenizer.py
+++ b/clkhash/tokenizer.py
@@ -1,8 +1,11 @@
 """
 Functions to tokenize words (PII)
 """
+from typing import Optional, List
+
 
 def unigramlist(instr, toremove=None, positional=False):
+    # type: (str, Optional[List[str]], bool) -> List[str]
     """
     Make 1-grams (unigrams) from a word, possibly excluding particular substrings
 
@@ -21,6 +24,7 @@ def unigramlist(instr, toremove=None, positional=False):
 
 
 def bigramlist(word, toremove=None):
+    # type: (str, Optional[List[str]]) -> List[str]
     """
     Make bigrams from word with pre- and ap-pended spaces
 
@@ -38,6 +42,7 @@ def bigramlist(word, toremove=None):
 
 
 def positional_unigrams(instr):
+    # type: (str) -> List[str]
     """
     Make positional unigrams from a word.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyYAML==3.12
 futures==3.1.1
 cryptography==2.1.3
 tqdm==4.19.1
+typing

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
 
 setup(
     name="clkhash",
-    version='0.8.0',
+    version='0.8.0-dev',
     description='Hash utility to create Cryptographic Linkage Keys',
     url='https://github.com/n1analytics/clkhash',
     license='Apache',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ requirements = [
         "requests==2.18.1",
         "futures==3.1.1",
         "cryptography==2.1.3",
-        "tqdm==4.19.4"
+        "tqdm==4.19.4",
+        "typing"
     ]
 
 setup(


### PR DESCRIPTION
Python 2 and 3 compatible type annotations for the mypy static type checker.


I've been testing with:
```
pip install mypy
mypy clkhash --ignore-missing-imports --strict-optional --no-implicit-optional --disallow-untyped-calls
```