### PR TITLE
Add a progress bar for cli based hashing

### DIFF
--- a/clkhash/benchmark.py
+++ b/clkhash/benchmark.py
@@ -6,7 +6,7 @@ from clkhash.schema import load_schema, get_schema_types
 from clkhash.clk import generate_clk_from_csv
 
 
-def compute_hash_speed(n):
+def compute_hash_speed(n, quiet=False):
     """
     Hash time.
     """
@@ -23,7 +23,7 @@ def compute_hash_speed(n):
 
     with open(tmpfile.name, 'rt') as f:
         start = timer()
-        generate_clk_from_csv(f, ('key1', 'key2'), schema)
+        generate_clk_from_csv(f, ('key1', 'key2'), schema, progress_bar=not quiet)
         end = timer()
     elapsed_time = end - start
     print("{:6d} hashes in {:.6f} seconds. {:.2f} KH/s".format(n, elapsed_time, n/(1000*elapsed_time)))

--- a/clkhash/cli.py
+++ b/clkhash/cli.py
@@ -50,8 +50,9 @@ def cli(verbose=False):
 @click.argument('keys', nargs=2, type=click.Tuple([str, str]))
 @click.option('--schema', '-s', type=click.File('r'), default=None)
 @click.argument('output', type=click.File('w'))
+@click.option('-q', '--quiet', default=False, is_flag=True, help="Quiet any progress messaging")
 @click.option('--no-header', default=False, is_flag=True, help="Don't skip the first row")
-def hash(input, output, schema, keys, no_header):
+def hash(input, output, schema, keys, quiet, no_header):
     """Process data to create CLKs
 
     Given a file containing csv data as INPUT, and optionally a json
@@ -69,7 +70,7 @@ def hash(input, output, schema, keys, no_header):
 
     schema_types = get_schema_types(load_schema(schema))
 
-    clk_data = clk.generate_clk_from_csv(input, keys, schema_types, no_header)
+    clk_data = clk.generate_clk_from_csv(input, keys, schema_types, no_header, not quiet)
     json.dump({'clks': clk_data}, output)
     log("CLK data written to {}".format(output.name))
 

--- a/clkhash/cli.py
+++ b/clkhash/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python3.6
 from __future__ import print_function
 
 import json

--- a/clkhash/clk.py
+++ b/clkhash/clk.py
@@ -72,11 +72,23 @@ def generate_clk_from_csv(input, keys, schema_types, no_header=False, progress_b
                                          chunk, schema_types, key_lists)
                 futures.append(future)
 
-            for future in tqdm(concurrent.futures.as_completed(futures),
-                               desc="Hashing",
-                               total=len(pii_data)//chunk_size,
-                               unit='KH',
-                               disable=not progress_bar):
+            if progress_bar:
+                future_iterator = tqdm(concurrent.futures.as_completed(futures),
+                                       desc="Hashing",
+                                       total=len(pii_data) // chunk_size,
+                                       unit='KH',
+                                       leave=False,
+                                       )
+            else:
+                future_iterator = concurrent.futures.as_completed(futures)
+
+            for f in future_iterator:
+                # Note these are not in order of submission - but completion!
+                # We do this noop loop inorder to deal with progress as the futures
+                # complete
+                pass
+
+            for future in futures:
                 results.extend(future.result())
 
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests==2.18.1
 PyYAML==3.12
 futures==3.1.1
 cryptography==2.1.3
+tqdm==4.19.1

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ requirements = [
         "click==6.7",
         "requests==2.18.1",
         "futures==3.1.1",
-        "cryptography==2.1.3"
+        "cryptography==2.1.3",
+        "tqdm==4.19.4"
     ]
 
 setup(

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -8,6 +8,6 @@ from clkhash import benchmark
 class TestBenchmark(unittest.TestCase):
 
     def test_benchmarking_hash(self):
-        speed = benchmark.compute_hash_speed(1000)
+        speed = benchmark.compute_hash_speed(1000, quiet=True)
         self.assertGreater(speed, 100, "Hashing at less than 100 H/s")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,6 @@ import yaml
 from click.testing import CliRunner
 
 
-
 class CLITestHelper(unittest.TestCase):
 
     samples = 100
@@ -197,18 +196,18 @@ class TestHashCommand(unittest.TestCase):
         with runner.isolated_filesystem():
 
             result = runner.invoke(clkhash.cli.cli, ['hash',
-                                                      '--schema',
-                                                      schema_file,
-                                                      a_pii,
-                                                      'a', 'b', '-'])
-            self.assertIn('clks', result.output)
+                                                     '--quiet',
+                                                     '--schema',
+                                                     schema_file,
+                                                     a_pii,
+                                                     'a', 'b', '-'])
 
             result_2 = runner.invoke(clkhash.cli.cli, ['hash',
-                                                      '--schema',
-                                                      schema_file,
-                                                      a_pii,
-                                                      'a', 'b', '-'])
-
+                                                       '--quiet',
+                                                       '--schema',
+                                                       schema_file,
+                                                       a_pii,
+                                                       'a', 'b', '-'])
         hasha = json.loads(result.output)['clks']
         hashb = json.loads(result_2.output)['clks']
 


### PR DESCRIPTION
Adds a simple progress bar for the command line utility.

![screenshot from 2017-12-13 14-35-54](https://user-images.githubusercontent.com/855189/33920821-2e63b71a-e014-11e7-98e8-2905ec716051.png)

I think the `generate_clk_from_csv` function should expose a better api for progress for other callers though - maybe a progress queue, or callback function?