### PR TITLE
recognise the `weight` of an identifier in filter generation

### DIFF
--- a/clkhash/bloomfilter.py
+++ b/clkhash/bloomfilter.py
@@ -33,7 +33,8 @@ def double_hash_encode_ngrams(ngrams,          # type: Iterable[str]
     :param key_md5: hmac secret keys for md5 as bytes
     :param k: number of hash functions to use per element of the ngrams
     :param l: length of the output bitarray
-    :return bitarray of length l with the bits set which correspond to the encoding of the ngrams
+
+    :return: bitarray of length l with the bits set which correspond to the encoding of the ngrams
     """
     bf = bitarray(l)
     bf.setall(False)
@@ -77,10 +78,9 @@ def crypto_bloom_filter(record,         # type: Tuple[Any, ...]
 
     for (entry, tokenizer, key1, key2) in zip(record, tokenizers, keys1, keys2):
         ngrams = [ngram for ngram in tokenizer(entry)]
-        if tokenizer.weight >= 0:
-            adjusted_k = int(round(tokenizer.weight * k))
-        else:
-            adjusted_k = k
+        if tokenizer.weight < 0:
+            raise ValueError('weight must not be smaller than zero, but was: {}'.format(tokenizer.weight))
+        adjusted_k = int(round(tokenizer.weight * k))
         bloomfilter |= double_hash_encode_ngrams(ngrams, key1, key2, adjusted_k, l)
 
     return bloomfilter, record[0], bloomfilter.count()

--- a/clkhash/bloomfilter.py
+++ b/clkhash/bloomfilter.py
@@ -77,7 +77,7 @@ def crypto_bloom_filter(record,         # type: Tuple[Any, ...]
     bloomfilter.setall(False)
 
     for (entry, tokenizer, key1, key2) in zip(record, tokenizers, keys1, keys2):
-        ngrams = [ngram for ngram in tokenizer(entry)]
+        ngrams = [ngram for ngram in tokenizer(str(entry))]
         if tokenizer.weight < 0:
             raise ValueError('weight must not be smaller than zero, but was: {}'.format(tokenizer.weight))
         adjusted_k = int(round(tokenizer.weight * k))

--- a/clkhash/bloomfilter.py
+++ b/clkhash/bloomfilter.py
@@ -77,7 +77,11 @@ def crypto_bloom_filter(record,         # type: Tuple[Any, ...]
 
     for (entry, tokenizer, key1, key2) in zip(record, tokenizers, keys1, keys2):
         ngrams = [ngram for ngram in tokenizer(entry)]
-        bloomfilter |= double_hash_encode_ngrams(ngrams, key1, key2, k, l)
+        if tokenizer.weight >= 0:
+            adjusted_k = int(round(tokenizer.weight * k))
+        else:
+            adjusted_k = k
+        bloomfilter |= double_hash_encode_ngrams(ngrams, key1, key2, adjusted_k, l)
 
     return bloomfilter, record[0], bloomfilter.count()
 

--- a/clkhash/identifier_types.py
+++ b/clkhash/identifier_types.py
@@ -4,6 +4,7 @@ Convert PII to tokens
 from typing import Dict, List, NoReturn, Any, Callable, Union, Optional
 
 from clkhash.tokenizer import unigramlist, bigramlist
+from copy import copy
 
 
 class IdentifierType:
@@ -115,6 +116,7 @@ def identifier_type_from_description(schema_object):
 
     # check if there was a custom weight
     if 'weight' in schema_object:
+        id_type = copy(id_type)  # we don't want to modify the original
         id_type.weight = schema_object['weight']
 
     return id_type

--- a/clkhash/identifier_types.py
+++ b/clkhash/identifier_types.py
@@ -46,7 +46,7 @@ class IdentifierType:
 
     def __call__(self, entry):
         # type: (str) -> List[str]
-        return self.tokenizer(entry, **self.kwargs)
+        return self.tokenizer(entry, **self.kwargs)  # type: ignore
 
 
 basic_types = {

--- a/clkhash/identifier_types.py
+++ b/clkhash/identifier_types.py
@@ -17,20 +17,27 @@ class IdentifierType:
     def __init__(self, unigram=False, weight=1, **kwargs):
         # type: (bool, float, Any) -> None
         """
-        :param unigram: Use uni-gram instead of using bi-grams
-        :param float weight: adjusts the "importance" of this identifier in the Bloom filter.
+        :param bool unigram: Use uni-gram instead of using bi-grams
+        :param float weight: adjusts the "importance" of this identifier in the Bloom filter. Can be set to zero to skip
         :param kwargs: Extra keyword arguments passed to the tokenizer
-        Can be set to zero to skip
 
-        Note on weight:
-        For each n-gram of an identifier, we compute k different indices in the Bloom filter which will be set to true.
-        There is a global default_k value, and the k value for each identifier is computed as k = weight * default_k.
-        Reasons why you might want to set weights:
-         - Long identifiers like street name will produce a lot more n-grams than small identifiers like zip code.
-           Thus street name will flip more bits in the Bloom filter and will have a bigger influence in the overall
-           matching score.
-         - The matching might produce better results if identifier that are stable and / or have low error rates are
-           given higher prominence in the Bloom filter.
+        .. Note::
+           For each n-gram of an identifier, we compute *k* different indices in the Bloom filter which will be set to
+           true. There is a global :math:`k_{default}` value, and the *k* value for each identifier is computed as
+
+           .. math::
+              k = weight * k_{default},
+
+           rounded to the nearest integer.
+
+           Reasons why you might want to set weights:
+
+             - Long identifiers like street name will produce a lot more n-grams than small identifiers like zip code.
+               Thus street name will flip more bits in the Bloom filter and will have a bigger influence in the overall
+               matching score.
+
+             - The matching might produce better results if identifiers that are stable and / or have low error rates
+               are given higher prominence in the Bloom filter.
 
         """
         self.weight = weight

--- a/clkhash/identifier_types.py
+++ b/clkhash/identifier_types.py
@@ -18,9 +18,20 @@ class IdentifierType:
         # type: (bool, float, Any) -> None
         """
         :param unigram: Use uni-gram instead of using bi-grams
-        :param float weight: adjusts at how many indices an n-gram of this identifier will appear in the Bloomfilter.
+        :param float weight: adjusts the "importance" of this identifier in the Bloom filter.
         :param kwargs: Extra keyword arguments passed to the tokenizer
         Can be set to zero to skip
+
+        Note on weight:
+        For each n-gram of an identifier, we compute k different indices in the Bloom filter which will be set to true.
+        There is a global default_k value, and the k value for each identifier is computed as k = weight * default_k.
+        Reasons why you might want to set weights:
+         - Long identifiers like street name will produce a lot more n-grams than small identifiers like zip code.
+           Thus street name will flip more bits in the Bloom filter and will have a bigger influence in the overall
+           matching score.
+         - The matching might produce better results if identifier that are stable and / or have low error rates are
+           given higher prominence in the Bloom filter.
+
         """
         self.weight = weight
         self.tokenizer = unigramlist if unigram else bigramlist

--- a/clkhash/identifier_types.py
+++ b/clkhash/identifier_types.py
@@ -15,25 +15,21 @@ class IdentifierType:
     """
 
     def __init__(self, unigram=False, weight=1, **kwargs):
-        # type: (bool, int, Any) -> None
+        # type: (bool, float, Any) -> None
         """
         :param unigram: Use uni-gram instead of using bi-grams
-        :param int weight: How many times to include this identifier.
+        :param float weight: adjusts at how many indices an n-gram of this identifier will appear in the Bloomfilter.
         :param kwargs: Extra keyword arguments passed to the tokenizer
         Can be set to zero to skip
         """
-        self.weight = int(weight)
+        self.weight = weight
         self.tokenizer = unigramlist if unigram else bigramlist
         self.kwargs = kwargs
 
     def __call__(self, entry):
         # type: (str) -> List[str]
-        result = []
-        for i in range(self.weight):
-            for token in self.tokenizer(entry, **self.kwargs):      # type: ignore
-                result.append(token)
+        return self.tokenizer(entry, **self.kwargs)
 
-        return result
 
 basic_types = {
     'INDEX': IdentifierType(weight=0),

--- a/tests/test_e2e_hashing.py
+++ b/tests/test_e2e_hashing.py
@@ -1,6 +1,7 @@
 import unittest
 from clkhash import randomnames, bloomfilter
 from clkhash.key_derivation import generate_key_lists
+from clkhash.identifier_types import IdentifierType
 
 
 class TestNamelistHashable(unittest.TestCase):
@@ -25,3 +26,27 @@ class TestNamelistHashable(unittest.TestCase):
 
         self.assertGreaterEqual(len(set1.intersection(set2)), 80,
                                 "Expected at least 80 hashes to be exactly the same")
+
+
+class TestHashingWithDifferentWeights(unittest.TestCase):
+    def test_different_weights(self):
+        pii = [['Deckard']]
+        keys = generate_key_lists(('secret', 'sauce'), 1)
+        it = [IdentifierType(weight=0)]
+        bf0 = bloomfilter.calculate_bloom_filters(pii, it, keys)[0]
+        it = [IdentifierType(weight=1)]
+        bf1 = bloomfilter.calculate_bloom_filters(pii, it, keys)[0]
+        it = [IdentifierType(weight=2)]
+        bf2 = bloomfilter.calculate_bloom_filters(pii, it, keys)[0]
+        it = [IdentifierType(weight=1.5)]
+        bf15 = bloomfilter.calculate_bloom_filters(pii, it, keys)[0]
+
+        self.assertEqual(bf0[0].count(), 0)
+        n1 = bf1[0].count()
+        n2 = bf2[0].count()
+        n15 = bf15[0].count()
+        self.assertGreater(n1, 0)
+        self.assertGreater(n15, n1)
+        self.assertGreater(n2, n15)
+        self.assertLessEqual(n15, round(n1*1.5))
+        self.assertLessEqual(n2, n1*2)


### PR DESCRIPTION
weight now adjusts the number of hash functions being used in the Bloom filter generation.

fixes #18