### PR TITLE
Feature always double encoding

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-#import os
-#import sys
-#sys.path.insert(0, os.path.abspath('./../clkhash'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- General configuration ------------------------------------------------

--- a/tests/test_bloomfilter.py
+++ b/tests/test_bloomfilter.py
@@ -1,5 +1,5 @@
 import unittest
-from clkhash.bloomfilter import double_hash_encode_ngrams, blake_encode_ngrams
+from clkhash.bloomfilter import double_hash_encode_ngrams, blake_encode_ngrams, double_hash_encode_ngrams_non_singular
 import random
 from copy import copy
 
@@ -21,6 +21,10 @@ class TestEncoding(unittest.TestCase):
         bf = blake_encode_ngrams(self.ngrams, self.key_sha1, self.k, 1024)
         self._test_bit_range(bf.count(), self.k, len(self.ngrams))
 
+    def test_double_hash_encoding_non_singular(self):
+        bf = double_hash_encode_ngrams_non_singular(self.ngrams, (self.key_sha1, self.key_md5), self.k, 1024)
+        self._test_bit_range(bf.count(), self.k, len(self.ngrams))
+
     def _test_bit_range(self, bits_set, k, num_ngrams):
         self.assertLessEqual(bits_set, num_ngrams * k)
         self.assertGreater(bits_set, k)
@@ -38,9 +42,28 @@ class TestEncoding(unittest.TestCase):
         self._test_order_of_ngrams(
             lambda ngrams: double_hash_encode_ngrams(ngrams, (self.key_sha1, self.key_md5), self.k, 1024),
             copy(self.ngrams))
+        self._test_order_of_ngrams(
+            lambda ngrams: double_hash_encode_ngrams_non_singular(ngrams, (self.key_sha1, self.key_md5), self.k, 1024),
+            copy(self.ngrams))
 
     def _test_order_of_ngrams(self, enc_function, ngrams):
         bf1 = enc_function(ngrams)
         random.shuffle(ngrams)
         bf2 = enc_function(ngrams)
         self.assertEqual(bf1, bf2)
+
+    def test_double_hash_singularity(self):
+        singular_ngrams = ["635", "1402"]
+        non_singular_ngrams = ["666", "1401"]
+        for ngram in singular_ngrams:
+            bf = double_hash_encode_ngrams([ngram], (b'secret1', b'secret2'), 20, 1024)
+            self.assertEqual(bf.count(), 1)
+            bf_ns = double_hash_encode_ngrams_non_singular([ngram], (b'secret1', b'secret2'), 20, 1024)
+            self.assertGreater(bf_ns.count(), 1)
+            self.assertNotEqual(bf, bf_ns)
+        for ngram in non_singular_ngrams:
+            bf = double_hash_encode_ngrams([ngram], (b'secret1', b'secret2'), 20, 1024)
+            self.assertGreater(bf.count(), 1)
+            bf_ns = double_hash_encode_ngrams_non_singular([ngram], (b'secret1', b'secret2'), 20, 1024)
+            self.assertGreater(bf_ns.count(), 1)
+            self.assertEqual(bf, bf_ns)


### PR DESCRIPTION
I added a modified version of the double hash encoding scheme which does not have the singularity weakness of the original one. See accompanying issue #33.
closes #33