### PR TITLE
Changelog for 0.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.10.0
+
+* Introduced a more secure variant of the double hash encoding scheme.
+* Introduced a Blake2 based encoding scheme. Still working on documentation.
+* Concurrent hashing now works on Windows as well as linux. This has also been backported to Python 2.
+* Command line tool now outputs basic statistics while hashing.
+* Command line tool is now officially supported on windows.
+
+We now build clkhash with continuous integration tools that anyone 
+can access [Travis CI](https://travis-ci.org/n1analytics/clkhash/) 
+and [AppVeyor](https://ci.appveyor.com/project/hardbyte/clkhash).
+
+
 ## 0.9.0
 
 * Adds the option to perform XOR folding. Schnell (2016) claims that it improves privacy whilst having little effect on accuracy; see [*XOR-Folding for hardening Bloom Filter based Encryptions for PPRL*](http://soz-159.uni-duisburg.de/wp-content/uploads/2017/07/XOR-Folding-for-Bloom.pdf) for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 * Introduced a more secure variant of the double hash encoding scheme.
 * Introduced a Blake2 based encoding scheme. Still working on documentation.
-* Concurrent hashing now works on Windows as well as linux. This has also been backported to Python 2.
+* Concurrent hashing now works on Windows as well as Linux. This has also been backported to Python 2.
 * Command line tool now outputs basic statistics while hashing.
-* Command line tool is now officially supported on windows.
+* Command line tool is now officially supported on Windows.
 
 We now build clkhash with continuous integration tools that anyone 
 can access [Travis CI](https://travis-ci.org/n1analytics/clkhash/) 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
 
 setup(
     name="clkhash",
-    version='0.10.0-rc.1',
+    version='0.10.0',
     description='Hash utility to create Cryptographic Linkage Keys',
     url='https://github.com/n1analytics/clkhash',
     license='Apache',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
 
 setup(
     name="clkhash",
-    version='0.9.0-dev',
+    version='0.10.0-rc.1',
     description='Hash utility to create Cryptographic Linkage Keys',
     url='https://github.com/n1analytics/clkhash',
     license='Apache',


### PR DESCRIPTION
This release candidate can be tested from PyPi:

```
$ pip install clkhash==0.10.0rc1
$ clkutil benchmark
generating CLKs: 100%|█████████████████████████████████████████████████████████████████| 10.0K/10.0K [00:01<00:00, 8.22Kclk/s, mean=521, std=34.4]
 10000 hashes in 1.267577 seconds. 7.89 KH/s
```