### PR TITLE
Fix generate_subsets method

### DIFF
--- a/clkhash/randomnames.py
+++ b/clkhash/randomnames.py
@@ -137,6 +137,8 @@ class NameList:
 
         :param sz: length of subsets to generate
         :param overlap: fraction of the subsets that should have the same names in them
+        :raises ValueError: if there aren't sufficiently many names in the list to satisfy
+            the request; more precisely, raises if sz + (1 - overlap)*sz > n = len(self.names)
         :return: pair of subsets
         """
         notoverlap = sz - int(math.floor(overlap * sz))

--- a/clkhash/randomnames.py
+++ b/clkhash/randomnames.py
@@ -132,13 +132,16 @@ class NameList:
 
     def generate_subsets(self, sz, overlap=0.8):
         """
-        Generate a pair of subsets of the name list with a specified overlap
+        Return a pair of random subsets of the name list with a specified
+        proportion of elements in common.
 
         :param sz: length of subsets to generate
         :param overlap: fraction of the subsets that should have the same names in them
-        :return: 2-tuple of lists of subsets
+        :return: pair of subsets
         """
         nrec = len(self.names)
+        assert sz <= nrec, 'Requested subset size exceeds the number of names'
+
         overlap = int(math.floor(overlap * sz))
         notoverlap = sz - overlap
         rsamp = random.sample(list(range(nrec)), sz + notoverlap)

--- a/clkhash/randomnames.py
+++ b/clkhash/randomnames.py
@@ -141,7 +141,8 @@ class NameList:
         """
         notoverlap = sz - int(math.floor(overlap * sz))
         total_sz = sz + notoverlap
-        assert total_sz <= len(self.names), \
-            'Requested subset size and overlap demands more than the number of available names'
+        if total_sz > len(self.names):
+            raise ValueError('Requested subset size and overlap demands more '
+                             + 'than the number of available names')
         sset = random.sample(self.names, total_sz)
         return sset[:sz], sset[notoverlap:]

--- a/clkhash/randomnames.py
+++ b/clkhash/randomnames.py
@@ -139,14 +139,9 @@ class NameList:
         :param overlap: fraction of the subsets that should have the same names in them
         :return: pair of subsets
         """
-        nrec = len(self.names)
-        assert sz <= nrec, 'Requested subset size exceeds the number of names'
-
-        overlap = int(math.floor(overlap * sz))
-        notoverlap = sz - overlap
-        rsamp = random.sample(list(range(nrec)), sz + notoverlap)
-        l1 = rsamp[:sz]
-        l2 = rsamp[:overlap] + rsamp[sz:sz + notoverlap]
-        random.shuffle(l1)
-        random.shuffle(l2)
-        return [self.names[i] for i in l1],  [self.names[i] for i in l2]
+        notoverlap = sz - int(math.floor(overlap * sz))
+        total_sz = sz + notoverlap
+        assert total_sz <= len(self.names), \
+            'Requested subset size and overlap demands more than the number of available names'
+        sset = random.sample(self.names, total_sz)
+        return sset[:sz], sset[notoverlap:]

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -26,6 +26,17 @@ class TestRandomNames(unittest.TestCase):
                     counteq += 1
         self.assertEqual(counteq, 8)
 
+    def test_generate_subsets_raises(self):
+        # sz = 999
+        # n = floor(sz * 1.2) = 1198
+        # overlap = floor(0.8 * 999) = 799
+        # notoverlap = sz - overlap = 200.
+        # Thus sz + notoverlap = 1199 > n.
+        sz = 999
+        nl = rn.NameList(sz * 1.2)
+        with pytest.raises(ValueError):
+            s1, s2 = nl.generate_subsets(sz, 0.8)
+
     def test_generate_large_subsets(self):
         nl = rn.NameList(2000)
         s1, s2 = nl.generate_subsets(1000, 0.5)

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -1,4 +1,5 @@
 import unittest
+import math
 from datetime import datetime
 
 from clkhash import randomnames as rn

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -1,5 +1,6 @@
 import unittest
 import math
+import pytest
 from datetime import datetime
 
 from clkhash import randomnames as rn

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -33,9 +33,10 @@ class TestRandomNames(unittest.TestCase):
         # notoverlap = sz - overlap = 200.
         # Thus sz + notoverlap = 1199 > n.
         sz = 999
-        nl = rn.NameList(sz * 1.2)
+        n = math.floor(sz * 1.2)
+        names = rn.NameList(n)
         with pytest.raises(ValueError):
-            s1, s2 = nl.generate_subsets(sz, 0.8)
+            s1, s2 = names.generate_subsets(sz, 0.8)
 
     def test_generate_large_subsets(self):
         nl = rn.NameList(2000)

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -35,7 +35,7 @@ class TestRandomNames(unittest.TestCase):
         # notoverlap = sz - overlap = 200.
         # Thus sz + notoverlap = 1199 > n.
         sz = 999
-        n = math.floor(sz * 1.2)
+        n = int(math.floor(sz * 1.2))
         names = rn.NameList(n)
         with pytest.raises(ValueError):
             s1, s2 = names.generate_subsets(sz, 0.8)


### PR DESCRIPTION
The `generate_subsets()` method in `NameList` did not protect against unreasonable parameters. Specifically, if it was asked to generate `n` names in the constructor, then `sz + (1 - overlap)*sz` must be less than `n` for `generate_subsets()` to be able to work. A `ValueError` is now raised if this condition is not met.

This PR also includes a considerable simplification of the code for generating the subsets, as well as a few improvements/clarifications to the documentation.

This PR is a precursor to a solution to entity-service/issues/99.