### PR TITLE
0.10.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.1
+
+* Major documentation updates.
+* Improvements and bug fix in data generation.
+* CI fix disable storing artifacts on AppVeyor.
+
 ## 0.10.0
 
 * Introduced a more secure variant of the double hash encoding scheme.
@@ -9,7 +15,6 @@
 We now build clkhash with continuous integration tools that anyone 
 can access [Travis CI](https://travis-ci.org/n1analytics/clkhash/) 
 and [AppVeyor](https://ci.appveyor.com/project/hardbyte/clkhash).
-
 
 ## 0.9.0
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is as described by Rainer Schnell, Tobias Bachteler, and Jörg Reiher in
 
 [![Documentation Status](https://readthedocs.org/projects/clkhash/badge/?version=latest)](http://clkhash.readthedocs.io/en/latest/?badge=latest)
 
+[![Build Status](https://travis-ci.org/n1analytics/clkhash.svg?branch=master)](https://travis-ci.org/n1analytics/clkhash)
 
 ## Installation
 

--- a/clkhash/bloomfilter.py
+++ b/clkhash/bloomfilter.py
@@ -87,9 +87,6 @@ def double_hash_encode_ngrams_non_singular(ngrams,          # type: Iterable[str
     irrespective of the value :math:`i`. A discussion of this potential flaw can be found
     `here <https://github.com/n1analytics/clkhash/issues/33>`_.
 
-    .. [Schnell2011] Schnell, R., Bachteler, T., & Reiher, J. (2011). A Novel Error-Tolerant Anonymous Linking Code.
-       http://soz-159.uni-duisburg.de/wp-content/uploads/2017/05/downloadwp-grlc-2011-02.pdf
-
     :param ngrams: list of n-grams to be encoded
     :param key_sha1: hmac secret keys for sha1 as bytes
     :param key_md5: hmac secret keys for md5 as bytes
@@ -160,19 +157,6 @@ def blake_encode_ngrams(ngrams,          # type: Iterable[str]
          | However, we think that using independent hash functions alone will not be sufficient to ensure security, since
            in this case other approaches (maybe related to or at least inspired through work from the area of Frequent
            Itemset Mining) are promising to detect at least the most frequent atoms automatically.
-
-    .. [Schnell2011] Schnell, R & Bachteler, T, and Reiher, J.
-       A Novel Error-Tolerant Anonymous Linking Code
-       http://www.record-linkage.de/-download=wp-grlc-2011-02.pdf
-
-    .. [Kroll2015] Kroll, M., & Steinmetzer, S. (2015).
-       Who is 1011011111...1110110010? automated cryptanalysis of bloom filter encryptions of databases with several
-       personal identifiers.
-       In Communications in Computer and Information Science. https://doi.org/10.1007/978-3-319-27707-3_21
-
-    .. [Kaminsky2011] Kaminsky, A. (2011).
-       GPU Parallel Statistical and Cube Test Analysis of the SHA-3 Finalist Candidate Hash Functions.
-       https://www.cs.rit.edu/~ark/parallelcrypto/sha3test01/jce2011.pdf
 
     :param ngrams: list of n-grams to be encoded
     :param key: secret key for blake2 as bytes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,8 +121,8 @@ html_logo = '_static/logo.svg'
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
 html_sidebars = {
     '**': [
-        'relations.html',  # needs 'show_related': True theme option to display
-        'searchbox.html',
+        'globaltoc.html',
+        'searchbox.html'
     ]
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,9 +2,29 @@
 clkhash: Cryptographic Linkage Key Hashing
 ==========================================
 
+
+``clkhash`` is a python implementation of cryptographic linkage key hashing as described by Rainer
+Schnell, Tobias Bachteler, and Jörg Reiher in *A Novel Error-Tolerant Anonymous Linking Code* [Schnell2011]_.
+
+Clkhash is Apache 2.0 licensed, supports Python versions 2.7+, 3.4+, and runs on Windows, OSX and Linux.
+
+Install with pip::
+
+    pip install clkhash
+
+
+.. hint::
+
+   If you are interested in comparing CLKs (i.e carrying out record linkage) you might want to check
+   out `anonlink <https://github.com/n1analytics/anonlink>`_ - our Python library for computing
+   similarity scores, and best guess matches between two sets of cryptographic linkage keys.
+
+
+Table of Contents
+-----------------
+
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+   :maxdepth: 1
 
    tutorial.ipynb
    cli
@@ -12,23 +32,15 @@ clkhash: Cryptographic Linkage Key Hashing
    development
    references
 
+External Links
+--------------
 
-
-``clkhash`` is a python implementation of cryptographic linkage key hashing as described by Rainer
-Schnell, Tobias Bachteler, and Jörg Reiher in *A Novel Error-Tolerant Anonymous Linking Code* [Schnell2011]_.
-
-It supports Python versions 2.7+, 3.4+ and runs on Windows, OSX and Linux.
-
-Install with pip::
-
-    pip install clkhash
+* `clkhash on Github <https://github.com/n1analytics/clkhash/>`_
+* `clkhash on PyPi <https://pypi.org/project/clkhash/>`_
 
 
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`
-* :ref:`search`
-
-

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -3,7 +3,23 @@
 References
 ==========
 
-.. [Schnell2011] Schnell, R., Bachteler, T., & Reiher, J. (2011). `A Novel Error-Tolerant Anonymous Linking Code <http://soz-159.uni-duisburg.de/wp-content/uploads/2017/05/downloadwp-grlc-2011-02.pdf>`_.
+.. [Schnell2011]
+   Schnell, R., Bachteler, T., & Reiher, J. (2011).
+   `A Novel Error-Tolerant Anonymous Linking Code <http://soz-159.uni-duisburg.de/wp-content/uploads/2017/05/downloadwp-grlc-2011-02.pdf>`_.
 
 
-.. [Schnell2016] Schnell, R., & Borgs, C. (2016). XOR-Folding for hardening Bloom Filter-based Encryptions for Privacy-preserving Record Linkage.
+.. [Schnell2016]
+   Schnell, R., & Borgs, C. (2016).
+   XOR-Folding for hardening Bloom Filter-based Encryptions for Privacy-preserving Record Linkage.
+
+
+.. [Kroll2015]
+   Kroll, M., & Steinmetzer, S. (2015).
+   Who is 1011011111...1110110010? automated cryptanalysis of bloom filter encryptions of databases with several
+   personal identifiers.
+   In Communications in Computer and Information Science. https://doi.org/10.1007/978-3-319-27707-3_21
+
+
+.. [Kaminsky2011] Kaminsky, A. (2011).
+   `GPU Parallel Statistical and Cube Test Analysis of the SHA-3 Finalist Candidate Hash Functions
+   <https://www.cs.rit.edu/~ark/parallelcrypto/sha3test01/jce2011.pdf>`_.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
 
 setup(
     name="clkhash",
-    version='0.10.0',
+    version='0.10.1',
     description='Hash utility to create Cryptographic Linkage Keys',
     url='https://github.com/n1analytics/clkhash',
     license='Apache',

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,14 @@ requirements = [
         "enum34==1.1.6; python_version < '3.4'"
     ]
 
+readme = open('README.md').read()
+
 setup(
     name="clkhash",
-    version='0.10.1',
+    version='0.10.1-rc2',
     description='Hash utility to create Cryptographic Linkage Keys',
+    long_description=readme,
+    long_description_content_type='text/markdown',
     url='https://github.com/n1analytics/clkhash',
     license='Apache',
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with codecs.open('README.md', 'r', 'utf-8') as f:
 
 setup(
     name="clkhash",
-    version='0.10.1-rc3',
+    version='0.10.1',
     description='Hash utility to create Cryptographic Linkage Keys',
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,11 @@ requirements = [
         "enum34==1.1.6; python_version < '3.4'"
     ]
 
-readme = open('README.md').read()
+readme = open('README.md', 'rt', encoding='utf8').read()
 
 setup(
     name="clkhash",
-    version='0.10.1-rc2',
+    version='0.10.1-rc3',
     description='Hash utility to create Cryptographic Linkage Keys',
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+import codecs
 
 requirements = [
         "bitarray==0.8.1",
@@ -13,7 +14,8 @@ requirements = [
         "enum34==1.1.6; python_version < '3.4'"
     ]
 
-readme = open('README.md', 'rt', encoding='utf8').read()
+with codecs.open('README.md', 'r', 'utf-8') as f:
+    readme = f.read()
 
 setup(
     name="clkhash",


### PR DESCRIPTION
Bump version and update changelog for `0.10.1`. 

Most likely the last release before #69 is merged in.

_Update_: Have just added another few commits to change the docs. Have pushed a release candidate to PyPy: https://pypi.org/project/clkhash/0.10.1rc2/

Can test it out with:
```
pip install clkhash==0.10.1rc2
```