### PR TITLE
the default shema was not quite right

### DIFF
--- a/clkhash/data/randomnames-schema.json
+++ b/clkhash/data/randomnames-schema.json
@@ -3,7 +3,7 @@
   "version": 1,
   "clkConfig": {
     "l": 1024,
-    "k": 20,
+    "k": 30,
     "hash": {
       "type": "doubleHash"
     },
@@ -23,8 +23,7 @@
       },
       "hashing": {
         "ngram": 1,
-        "weight": 1,
-        "positional": true
+        "weight": 0
       }
     },
     {


### PR DESCRIPTION
we do not want to hash INDEX and k was too small. With k=30 we set about 430 bits.