### PR TITLE
This should fix cli.create

### DIFF
--- a/clkhash/cli.py
+++ b/clkhash/cli.py
@@ -148,8 +148,8 @@ def create(type, schema, server, output, threshold, verbose):
     log("Server Status: {}".format(status))
 
     if schema is not None:
-        schema_object = load_schema(schema)
-        schema_json = json.dumps(schema_object)
+        schema_json = json.load(schema)
+        clkhash.schema.Schema.from_json_dict(schema_json)
     else:
         schema_json = 'NOT PROVIDED'
 


### PR DESCRIPTION
`cli.create` used to break because `load_schema` no longer exists. This should fix it.