### PR TITLE
Fix integer validation.

### DIFF
--- a/clkhash/field_formats.py
+++ b/clkhash/field_formats.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals
 import abc
 from datetime import datetime
 import re
+import string
 from typing import Any, cast, Dict, Iterable, Optional, Text, Union
 
 from future.builtins import super
@@ -430,6 +431,13 @@ class IntegerSpec(FieldSpec):
             :raises InvalidEntryError: When entry is invalid.
         """
         super().validate(str_in)
+
+        if any(d not in string.digits for d in str_in):
+            msg = ('An integer cannot contain non-digit characters. '
+                   "Read '{}'.".format(str_in))
+            e_new = InvalidEntryError(msg)
+            e_new.field_spec = self
+            raise e_new
 
         try:
             value = int(str_in, base=10)

--- a/tests/test_field_formats.py
+++ b/tests/test_field_formats.py
@@ -169,6 +169,14 @@ class TestFieldFormats(unittest.TestCase):
         with self.assertRaises(field_formats.InvalidEntryError):
             spec.validate(str(-math.pi))
 
+        # int() may accept these, but we don't.
+        with self.assertRaises(field_formats.InvalidEntryError):
+            spec.validate('  10')
+        with self.assertRaises(field_formats.InvalidEntryError):
+            spec.validate('10  ')
+        with self.assertRaises(field_formats.InvalidEntryError):
+            spec.validate('+10')
+
         # Ok, let's put a 'minimum' and 'maximum' in.
         regex_spec['format']['minimum'] = 8
         regex_spec['format']['maximum'] = 12


### PR DESCRIPTION
No longer permit strings such as ' 42', '42 ', or '+42'. Closes #119.