### PR TITLE
Use iterators to avoid unnecessary memory allocation

### DIFF
--- a/clkhash/bloomfilter.py
+++ b/clkhash/bloomfilter.py
@@ -14,7 +14,7 @@ import struct
 from typing import Callable, Iterable, List, Sequence, Text, Tuple
 
 from bitarray import bitarray
-from future.builtins import range
+from future.builtins import range, zip
 
 from clkhash import tokenizer
 from clkhash.backports import int_from_bytes

--- a/clkhash/clk.py
+++ b/clkhash/clk.py
@@ -8,6 +8,7 @@ import time
 from typing import (AnyStr, Callable, Iterable, List, Optional,
                     Sequence, TextIO, Tuple, TypeVar, Union)
 
+from future.builtins import range
 from tqdm import tqdm
 
 from clkhash.backports import unicode_reader
@@ -98,7 +99,7 @@ def generate_clk_from_csv(input_f,             # type: TextIO
     # Read the lines in CSV file and add it to PII
     pii_data = []
     for line in reader:
-        pii_data.append(tuple([element.strip() for element in line]))
+        pii_data.append(tuple(element.strip() for element in line))
 
     validate_row_lengths(schema.fields, pii_data)
 

--- a/clkhash/field_formats.py
+++ b/clkhash/field_formats.py
@@ -13,7 +13,7 @@ import re
 import string
 from typing import Any, cast, Dict, Iterable, Optional, Text, Union
 
-from future.builtins import super
+from future.builtins import range, super
 from future.utils import raise_from
 from six import add_metaclass
 

--- a/clkhash/key_derivation.py
+++ b/clkhash/key_derivation.py
@@ -3,6 +3,7 @@ from typing import cast, Tuple, Union, Optional, Sequence, Any
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.backends import default_backend
+from future.builtins import range, zip
 
 
 """
@@ -115,7 +116,7 @@ def hkdf(hkdf_config, num_keys, key_size=DEFAULT_KEY_SIZE):
     # hkdf.derive returns a block of num_keys * key_size bytes which we divide up into num_keys chunks,
     # each of size key_size
     keybytes = hkdf.derive(hkdf_config.master_secret)
-    keys = tuple([keybytes[i * key_size:(i + 1) * key_size] for i in range(num_keys)])
+    keys = tuple(keybytes[i * key_size:(i + 1) * key_size] for i in range(num_keys))
     return keys
 
 
@@ -166,5 +167,5 @@ def generate_key_lists(master_secrets,              # type: Sequence[Union[bytes
         # regroup such that we get a tuple of keys for each identifier
         return tuple(zip(*key_lists))
     if kdf == 'legacy':
-        return tuple([tuple(keys) for _ in range(num_identifier)])
+        return tuple(tuple(keys) for _ in range(num_identifier))
     raise ValueError('kdf: "{}" is not supported.'.format(kdf))

--- a/clkhash/randomnames.py
+++ b/clkhash/randomnames.py
@@ -23,6 +23,8 @@ import random
 import re
 from typing import Dict, Iterable, List, Sequence, TextIO, Tuple, Union
 
+from future.builtins import range
+
 from clkhash.schema import Schema
 from clkhash.field_formats import FieldSpec
 

--- a/clkhash/schema.py
+++ b/clkhash/schema.py
@@ -10,6 +10,7 @@ import json
 import pkgutil
 from typing import Any, Dict, Hashable, List, Sequence, Text, TextIO
 
+from future.builtins import map
 from future.utils import raise_from
 import jsonschema
 

--- a/clkhash/tokenizer.py
+++ b/clkhash/tokenizer.py
@@ -8,6 +8,8 @@ from __future__ import unicode_literals
 import functools
 from typing import AnyStr, Callable, Iterable, Optional, Text
 
+from future.builtins import range
+
 from clkhash import field_formats
 
 

--- a/clkhash/validate_data.py
+++ b/clkhash/validate_data.py
@@ -8,6 +8,7 @@
 
 from typing import Optional, Sequence
 
+from future.builtins import zip
 from future.utils import raise_from
 
 from clkhash.field_formats import (FieldSpec, InvalidEntryError,

--- a/tests/test_bloomfilter.py
+++ b/tests/test_bloomfilter.py
@@ -3,6 +3,8 @@ import base64
 import random
 import unittest
 
+from future.builtins import range
+
 from clkhash.bloomfilter import (
     blake_encode_ngrams, double_hash_encode_ngrams,
     double_hash_encode_ngrams_non_singular, NgramEncodings)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ import time
 import unittest
 
 from click.testing import CliRunner
+from future.builtins import range
 
 import clkhash
 import clkhash.cli
@@ -108,7 +109,7 @@ class BasicCLITests(unittest.TestCase):
     def test_list_commands(self):
         runner = CliRunner()
         result = runner.invoke(clkhash.cli.cli, [])
-        for expected_command in set(['hash', 'upload', 'create', 'results', 'generate', 'benchmark']):
+        for expected_command in 'hash', 'upload', 'create', 'results', 'generate', 'benchmark':
             assert expected_command in result.output
 
     def test_version(self):

--- a/tests/test_clk.py
+++ b/tests/test_clk.py
@@ -7,6 +7,7 @@ import io
 import unittest
 
 from clkhash import clk, schema, randomnames, validate_data
+from future.builtins import range
 
 
 class TestChunks(unittest.TestCase):

--- a/tests/test_key_derivation.py
+++ b/tests/test_key_derivation.py
@@ -1,6 +1,8 @@
 import base64
 import unittest
 
+from future.builtins import zip
+
 from clkhash.bloomfilter import stream_bloom_filters
 from clkhash.key_derivation import hkdf, generate_key_lists, DEFAULT_KEY_SIZE, HKDFconfig
 from clkhash.schema import GlobalHashingProperties, Schema

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -1,7 +1,9 @@
-import unittest
-import math
-import pytest
 from datetime import datetime
+import math
+import unittest
+
+from future.builtins import range
+import pytest
 
 from clkhash import randomnames as rn
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,4 +1,6 @@
 import random
+
+from future.builtins import range
 from pytest import approx, raises
 
 from clkhash.stats import OnlineMeanVariance


### PR DESCRIPTION
In a bunch of places we’ve been unnecessarily allocating memory by making lists. This pull request does the following two things to avoid that:

- Imports `range`, `map`, `zip` from `future` when appropriate. These are the versions that are iterators.
- Recognises that `tuple` and `set` will happily accept an iterator, so no need to make a list first.