### PR TITLE
Feature support better date type

### DIFF
--- a/clkhash/backports.py
+++ b/clkhash/backports.py
@@ -6,7 +6,8 @@ import time
 from datetime import datetime
 from typing import Text
 
-from mypy_extensions import Arg, DefaultNamedArg
+from future.utils import raise_from as __raise_from
+from mypy_extensions import Arg, DefaultNamedArg, NoReturn
 
 
 try:
@@ -170,3 +171,7 @@ else:
         for site in sites:
             s = s[:site] + syear + s[site + 4:]
         return s
+
+
+# Help MyPy understand that this always throws.
+raise_from = cast(Callable[[Exception, Exception], NoReturn], __raise_from)

--- a/clkhash/backports.py
+++ b/clkhash/backports.py
@@ -3,6 +3,8 @@ from typing import AnyStr, Callable, cast, Pattern, Sequence
 import re
 import sys
 import time
+from datetime import datetime
+from typing import Text
 
 from mypy_extensions import Arg, DefaultNamedArg
 
@@ -103,6 +105,7 @@ unicode_reader = (_p2_unicode_reader  # Python 2 with hacky workarounds.
 
 if sys.version_info > (3, 2):
     def strftime(dt, fmt):
+        # type: (datetime, Text) -> Text
         return dt.strftime(fmt)
 else:
     # remove the unsupposed "%s" command.  But don't
@@ -128,6 +131,7 @@ else:
         return sites
 
     def strftime(dt, fmt):
+        # type: (datetime, Text) -> Text
         """ sensible version of strftime for python < 3.2. The one from the standard library does not support years < 1900.
         Kudos: https://github.com/ActiveState/code/blob/master/recipes/Python/306860_proleptic_Gregoridates_strftime_before/recipe-306860.py
 

--- a/clkhash/backports.py
+++ b/clkhash/backports.py
@@ -2,6 +2,7 @@ import csv
 from typing import AnyStr, Callable, cast, Pattern, Sequence
 import re
 import sys
+import time
 
 from mypy_extensions import Arg, DefaultNamedArg
 
@@ -98,3 +99,70 @@ def _p2_unicode_reader(unicode_csv_data, dialect=csv.excel, **kwargs):
 unicode_reader = (_p2_unicode_reader  # Python 2 with hacky workarounds.
                   if sys.version_info < (3,0)
                   else csv.reader)  # Py3 with native Unicode support.
+
+
+if sys.version_info > (3, 2):
+    def strftime(dt, fmt):
+        return dt.strftime(fmt)
+else:
+    # remove the unsupposed "%s" command.  But don't
+    # do it if there's an even number of %s before the s
+    # because those are all escaped.  Can't simply
+    # remove the s because the result of
+    #  %sY
+    # should be %Y if %s isn't supported, not the
+    # 4 digit year.
+    _illegal_s = re.compile(r"((^|[^%])(%%)*%s)")
+
+
+    def _findall(text, substr):
+        # Also finds overlaps
+        sites = []
+        i = 0
+        while 1:
+            j = text.find(substr, i)
+            if j == -1:
+                break
+            sites.append(j)
+            i = j + 1
+        return sites
+
+    def strftime(dt, fmt):
+        """ sensible version of strftime for python < 3.2. The one from the standard library does not support years < 1900.
+        Kudos: https://github.com/ActiveState/code/blob/master/recipes/Python/306860_proleptic_Gregoridates_strftime_before/recipe-306860.py
+
+        # Every 28 years the calendar repeats, except through century leap
+        # years where it's 6 years.  But only if you're using the Gregorian
+        # calendar.  ;)
+        """
+        if _illegal_s.search(fmt):
+            raise TypeError("This strftime implementation does not handle %s")
+        if dt.year > 1900:
+            return dt.strftime(fmt)
+
+        year = dt.year
+        # For every non-leap year century, advance by
+        # 6 years to get into the 28-year repeat cycle
+        delta = 2000 - year
+        off = 6 * (delta // 100 + delta // 400)
+        year = year + off
+
+        # Move to around the year 2000
+        year = year + ((2000 - year) // 28) * 28
+        timetuple = dt.timetuple()
+        s1 = time.strftime(fmt, (year,) + timetuple[1:])
+        sites1 = _findall(s1, str(year))
+
+        s2 = time.strftime(fmt, (year + 28,) + timetuple[1:])
+        sites2 = _findall(s2, str(year + 28))
+
+        sites = []
+        for site in sites1:
+            if site in sites2:
+                sites.append(site)
+
+        s = s1
+        syear = "%4d" % (dt.year,)
+        for site in sites:
+            s = s[:site] + syear + s[site + 4:]
+        return s

--- a/clkhash/bloomfilter.py
+++ b/clkhash/bloomfilter.py
@@ -19,7 +19,7 @@ from future.builtins import range, zip
 from clkhash import tokenizer
 from clkhash.backports import int_from_bytes
 from clkhash.schema import Schema, GlobalHashingProperties
-from clkhash.field_formats import FieldHashingProperties
+from clkhash.field_formats import FieldSpec
 
 try:
     from hashlib import blake2b

--- a/clkhash/bloomfilter.py
+++ b/clkhash/bloomfilter.py
@@ -280,7 +280,7 @@ def fold_xor(bloomfilter,  # type: bitarray
 
 def crypto_bloom_filter(record,          # type: Sequence[Text]
                         tokenizers,      # type: List[Callable[[Text], Iterable[Text]]]
-                        fields,          # type: List[FieldSpec]
+                        fields,          # type: Sequence[FieldSpec]
                         keys,            # type: Sequence[Sequence[bytes]]
                         hash_properties  # type: GlobalHashingProperties
                         ):

--- a/clkhash/bloomfilter.py
+++ b/clkhash/bloomfilter.py
@@ -280,7 +280,7 @@ def fold_xor(bloomfilter,  # type: bitarray
 
 def crypto_bloom_filter(record,          # type: Sequence[Text]
                         tokenizers,      # type: List[Callable[[Text], Iterable[Text]]]
-                        field_hashing,   # type: List[FieldHashingProperties]
+                        fields,          # type: List[FieldSpec]
                         keys,            # type: Sequence[Sequence[bytes]]
                         hash_properties  # type: GlobalHashingProperties
                         ):
@@ -292,9 +292,9 @@ def crypto_bloom_filter(record,          # type: Sequence[Text]
     http://www.record-linkage.de/-download=wp-grlc-2011-02.pdf
 
     :param record: plaintext record tuple. E.g. (index, name, dob, gender)
-    :param tokenizers: A tokenizers. A tokenizer is a function that
+    :param tokenizers: A list of tokenizers. A tokenizer is a function that
         returns tokens from a string.
-    :param field_hashing: Hashing properties for each field.
+    :param fields: A list of FieldSpec. One for each field.
     :param keys: Keys for the hash functions as a tuple of lists of bytes.
     :param hash_properties: Global hashing properties.
 
@@ -311,14 +311,16 @@ def crypto_bloom_filter(record,          # type: Sequence[Text]
     bloomfilter = bitarray(l)
     bloomfilter.setall(False)
 
-    for (entry, tokenizer, field, key) \
-            in zip(record, tokenizers, field_hashing, keys):
-        entry = field.replace_missing_value(entry)
-        ngrams = tokenizer(entry)
-        adjusted_k = int(round(field.weight * k))
+    for (entry, tokenize, field, key) \
+            in zip(record, tokenizers, fields, keys):
+        hash_props = field.hashing_properties
+
+        ngrams = tokenize(field.format_value(entry))
+
+        adjusted_k = int(round(hash_props.weight * k))
 
         bloomfilter |= hash_function(
-            ngrams, key, adjusted_k, l, field.encoding)
+            ngrams, key, adjusted_k, l, hash_props.encoding)
 
     bloomfilter = fold_xor(bloomfilter, xor_folds)
 
@@ -341,10 +343,9 @@ def stream_bloom_filters(dataset,  # type: Iterable[Sequence[Text]]
     """
     tokenizers = [tokenizer.get_tokenizer(field.hashing_properties)
                   for field in schema.fields]
-    field_hashing = [field.hashing_properties for field in schema.fields]
     hash_properties = schema.hashing_globals
 
-    return (crypto_bloom_filter(s, tokenizers, field_hashing,
+    return (crypto_bloom_filter(s, tokenizers, schema.fields,
                                 keys, hash_properties)
             for s in dataset)
 

--- a/clkhash/data/randomnames-schema.json
+++ b/clkhash/data/randomnames-schema.json
@@ -42,10 +42,9 @@
     {
       "identifier": "DOB YYYY/MM/DD",
       "format": {
-        "type": "string",
-        "encoding": "ascii",
+        "type": "date",
         "description": "Numbers separated by slashes, in the year, month, day order",
-        "pattern": "(?:\\d\\d\\d\\d/\\d\\d/\\d\\d)\\Z"
+        "format": "%Y/%m/%d"
       },
       "hashing": {
         "ngram": 1,

--- a/clkhash/field_formats.py
+++ b/clkhash/field_formats.py
@@ -646,6 +646,8 @@ class DateSpec(FieldSpec):
             e_new = InvalidEntryError(msg)
             e_new.field_spec = self
             raise_from(e_new, e)
+            raise None  # otherwise mypy complains about missing return statement. It can't understand 'raise_from'
+
 
 
 class EnumSpec(FieldSpec):

--- a/clkhash/field_formats.py
+++ b/clkhash/field_formats.py
@@ -18,6 +18,7 @@ from future.utils import raise_from
 from six import add_metaclass
 
 from clkhash.backports import re_compile_full
+from clkhash.backports import strftime
 
 
 class InvalidEntryError(ValueError):
@@ -639,9 +640,9 @@ class DateSpec(FieldSpec):
         """
         try:
             dt = datetime.strptime(str_in, self.format)
-            return dt.date().strftime(DateSpec.OUTPUT_FORMAT)
+            return strftime(dt, DateSpec.OUTPUT_FORMAT)
         except ValueError as e:
-            msg = "Date does not conform to specification '{}'. Read '{}'.".format(self.format, str_in)
+            msg = "Unable to format date value '{}'. Reason: {}".format(str_in, e)
             e_new = InvalidEntryError(msg)
             e_new.field_spec = self
             raise_from(e_new, e)

--- a/clkhash/field_formats.py
+++ b/clkhash/field_formats.py
@@ -14,11 +14,9 @@ import string
 from typing import Any, cast, Dict, Iterable, Optional, Text, Union
 
 from future.builtins import range, super
-from future.utils import raise_from
 from six import add_metaclass
 
-from clkhash.backports import re_compile_full
-from clkhash.backports import strftime
+from clkhash.backports import re_compile_full, strftime, raise_from
 
 
 class InvalidEntryError(ValueError):
@@ -646,7 +644,6 @@ class DateSpec(FieldSpec):
             e_new = InvalidEntryError(msg)
             e_new.field_spec = self
             raise_from(e_new, e)
-            raise None  # otherwise mypy complains about missing return statement. It can't understand 'raise_from'
 
 
 

--- a/clkhash/field_formats.py
+++ b/clkhash/field_formats.py
@@ -226,13 +226,43 @@ class FieldSpec(object):
         """ tests if 'str_in' is the sentinel value for this field
 
             :param str str_in: String to test if it stands for missing value
-            :returns True if a missing value is defined for this field and str_in matches this value
+            :return: True if a missing value is defined for this field and str_in matches this value
 
         """
         if self.hashing_properties.missing_value is not None:
             if self.hashing_properties.missing_value.sentinel == str_in:
                 return True
         return False
+
+    def format_value(self, str_in):
+        # type: (Text) -> Text
+        """ formats the value 'str_in' for hashing according to this field's spec.
+
+            There are several reasons why this might be necessary:
+
+            1. This field contains missing values which have to be replaced by some other string
+            2. There are several different ways to describe a specific value for this field, e.g.: all of '+65', ' 65',
+               '65' are valid representations of the integer 65.
+            3. Entries of this field might contain elements with no entropy, e.g. dates might be formatted as
+               yyyy-mm-dd, thus all dates will have '-' at the same place. These artifacts have no value for entity
+               resolution and should be removed.
+
+            :param str str_in: the string to format
+            :return: a string representation of 'str_in' which is ready to be hashed
+        """
+        if self.is_missing_value(str_in):
+            return self.hashing_properties.replace_missing_value(str_in)
+        else:
+            return self._format_regular_value(str_in)
+
+    def _format_regular_value(self, str_in):
+        # type: (Text) -> Text
+        """ overwrite this if you want to modify 'str_in' before hashing.
+
+            :param str_in:
+            :return: a string representation of 'str_in' which is ready to be hashed
+        """
+        return str_in
 
 
 class StringSpec(FieldSpec):
@@ -528,15 +558,14 @@ class IntegerSpec(FieldSpec):
 class DateSpec(FieldSpec):
     """ Represents a field that holds dates.
 
-       Dates are specified as full-dates as defined in
-       `RFC3339 <https://tools.ietf.org/html/rfc3339>`_ E.g.,
-       ``1996-12-19``
+       Dates are specified as full-dates in a format that can be described as a *strptime()* (C89 standard) compatible
+       format string.
+       E.g.: the format for the standard internet format `RFC3339 <https://tools.ietf.org/html/rfc3339>`_
+       (e.g. 1996-12-19) is '%Y-%m-%d'.
 
         :ivar str format: The format of the date.
     """
-    _PERMITTED_FORMATS = {'rfc3339'}
-    _RFC3339_REGEX = re_compile_full(r'\d\d\d\d-\d\d-\d\d')
-    _RFC3339_FORMAT = '%Y-%m-%d'
+    OUTPUT_FORMAT = '%Y%m%d'
 
     def __init__(self,
                  identifier,          # type: str
@@ -552,11 +581,8 @@ class DateSpec(FieldSpec):
                          description=description,
                          hashing_properties=hashing_properties)
 
-        if format not in self._PERMITTED_FORMATS:
-            msg = 'No validation for date format: {}.'.format(format)
-            raise NotImplementedError(msg)
-
         self.format = format
+
 
     @classmethod
     def from_json_dict(cls, json_dict):
@@ -596,25 +622,29 @@ class DateSpec(FieldSpec):
         if self.is_missing_value(str_in):
             return
         super().validate(str_in)
+        try:
+            datetime.strptime(str_in, self.format)
+        except ValueError as e:
+            msg = "Validation error for date type: {}".format(e)
+            e_new = InvalidEntryError(msg)
+            e_new.field_spec = self
+            raise_from(e_new, e)
 
-        if self.format == 'rfc3339':
-            if self._RFC3339_REGEX.match(str_in) is None:
-                msg = ("Date expected to conform to RFC3339. Read '{}'."
-                       .format(str_in))
-                e = InvalidEntryError(msg)
-                e.field_spec = self
-                raise e
-            try:
-                datetime.strptime(str_in, self._RFC3339_FORMAT)
-            except ValueError as e:
-                msg = "Invalid date. Read '{}'.".format(str_in)
-                e_new = InvalidEntryError(msg)
-                e_new.field_spec = self
-                raise_from(e_new, e)
+    def _format_regular_value(self, str_in):
+        # type: (Text) -> Text
+        """ we overwrite default behaviour as we want to hash the numbers only, no fillers like '-', or '/'
 
-        else:
-            msg = 'No validation for date format: {}.'.format(self.format)
-            raise NotImplementedError(msg)
+        :param str str_in: date string
+        :return: str date string with format DateSpec.OUTPUT_FORMAT
+        """
+        try:
+            dt = datetime.strptime(str_in, self.format)
+            return dt.date().strftime(DateSpec.OUTPUT_FORMAT)
+        except ValueError as e:
+            msg = "Date does not conform to specification '{}'. Read '{}'.".format(self.format, str_in)
+            e_new = InvalidEntryError(msg)
+            e_new.field_spec = self
+            raise_from(e_new, e)
 
 
 class EnumSpec(FieldSpec):

--- a/clkhash/master-schemas/v1.json
+++ b/clkhash/master-schemas/v1.json
@@ -149,7 +149,7 @@
       "additionalProperties": false,
       "properties": {
         "type": {"enum": ["date"]},
-        "format": {"enum": ["rfc3339"], "description": "standard internet format: yyyy-mm-dd"},
+        "format": {"type": "string", "description": "describes the format of the date in 'strptime' format"},
         "description": {"type": "string"}
       }
     },

--- a/clkhash/schema.py
+++ b/clkhash/schema.py
@@ -11,9 +11,9 @@ import pkgutil
 from typing import Any, Dict, Hashable, List, Sequence, Text, TextIO
 
 from future.builtins import map
-from future.utils import raise_from
 import jsonschema
 
+from clkhash.backports import raise_from
 from clkhash.field_formats import FieldSpec, spec_from_json_dict
 from clkhash.key_derivation import DEFAULT_KEY_SIZE as DEFAULT_KDF_KEY_SIZE
 

--- a/clkhash/validate_data.py
+++ b/clkhash/validate_data.py
@@ -9,8 +9,8 @@
 from typing import Optional, Sequence
 
 from future.builtins import zip
-from future.utils import raise_from
 
+from clkhash.backports import raise_from
 from clkhash.field_formats import (FieldSpec, InvalidEntryError,
                                    InvalidSchemaError)
 

--- a/docs/_static/example_schema.json
+++ b/docs/_static/example_schema.json
@@ -135,6 +135,18 @@
       }
     },
     {
+      "identifier": "dob",
+      "format": {
+        "type": "date",
+        "format": "%Y-%m-%d",
+        "description": "The full date of birth (eg: 1965-12-24)"
+      },
+      "hashing": {
+        "ngram": 1,
+        "positional": true
+      }
+    },
+    {
       "identifier": "addressKey",
       "format": {
         "type": "string",

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -296,14 +296,29 @@ description string                 yes      free text, ignored by clkhash.
 
 dateFormat
 ^^^^^^^^^^^^^
+A date is described by an ISO C89 compatible strftime() format string. For example, the format string for the internet
+date format as described in rfc3339, would be '%Y-%m-%d'.
+The clkhash library will convert the given date to the '%Y%m%d' representation for hashing, as any fill character like
+'-' or '/' do not add to the uniqueness of an entity.
 
 =========== =====================  ======== ===========
 name        type                   optional description
 =========== =====================  ======== ===========
 type        string                 no       has to be "date"
-format      enum                   no       one of ["rfc3339"]. That's the standard internet format: yyyy-mm-dd.
+format      string                 no       ISO C89 compatible format string, eg: for 1989-11-09 the format is '%Y-%m-%d'
 description string                 yes      free text, ignored by clkhash.
 =========== =====================  ======== ===========
+
+The following subset contains the most useful format codes:
+
+========= ======================================== ==================
+directive meaning                                  example
+========= ======================================== ==================
+%Y        Year with century as a decimal number    1984, 3210, 0001
+%y        Year without century, zero-padded        00, 09, 99
+%m        Month as a zero-padded decimal number    01, 12
+%d        Day of the month, zero-padded            01, 25, 31
+========= ======================================== ==================
 
 
 .. _schema/efo:

--- a/tests/test_clk.py
+++ b/tests/test_clk.py
@@ -68,7 +68,7 @@ class TestComplexSchemaChanges(unittest.TestCase):
                     identifier='dob',
                     format=dict(
                         type='date',
-                        format='rfc3339',
+                        format='%Y-%m-%d',
                         description='When were ya born?'),
                     hashing=dict(
                         ngram=2,

--- a/tests/test_field_formats.py
+++ b/tests/test_field_formats.py
@@ -242,7 +242,7 @@ class TestFieldFormats(unittest.TestCase):
             identifier='dates',
             format=dict(
                 type='date',
-                format='rfc3339',
+                format='%Y-%m-%d',
                 description='phoenix dactylifera'),
             hashing=dict(
                 ngram=0,
@@ -270,10 +270,6 @@ class TestFieldFormats(unittest.TestCase):
             spec.validate('2006-03-52')
 
         # These formats are incorrect.
-        with self.assertRaises(field_formats.InvalidEntryError):
-            spec.validate('2006-3-20')
-        with self.assertRaises(field_formats.InvalidEntryError):
-            spec.validate('1946-06-1')
         with self.assertRaises(field_formats.InvalidEntryError):
             spec.validate('194-06-14')
         with self.assertRaises(field_formats.InvalidEntryError):
@@ -320,6 +316,25 @@ class TestFieldFormats(unittest.TestCase):
         self.assertEqual(spec.hashing_properties.ngram, 0)
         self.assertIs(spec.hashing_properties.positional, False)
         self.assertEqual(spec.hashing_properties.weight, 1)
+
+        # check for graceful fail if format spec is invalid
+        spec.format = 'invalid%'
+        with self.assertRaises(field_formats.InvalidEntryError):
+            spec.validate('2018-01-23')
+
+    def test_date_output_formatting(self):
+        regex_spec = dict(
+            identifier='dates',
+            format=dict(
+                type='date',
+                format='%Y:%m-%d'),
+            hashing=dict(ngram=0))
+
+        spec = field_formats.spec_from_json_dict(regex_spec)
+        from datetime import date
+        from clkhash.field_formats import DateSpec
+        d = date.today()
+        assert spec.format_value(d.strftime(regex_spec['format']['format'])) == d.strftime(DateSpec.OUTPUT_FORMAT)
 
     def test_enum(self):
         spec_dict = dict(

--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -39,7 +39,7 @@ class FieldsMaker(unittest.TestCase):
             ),
             DateSpec(
                 identifier='join date',
-                format='rfc3339',
+                format='%Y-%m-%d',
                 hashing_properties=ascii_hashing
             ),
             EnumSpec(


### PR DESCRIPTION
The date spec is now a bit more sensible. 

The problems I solved are:
- only one allowed date type
- we hashed unnecessary characters like '-'

The master schema changed such that it allows defining dates with a format string just like in `strftime()`. 
A FieldSpec now has an additional `format_value` function which will return a given field value nicely formatted for hashing. FieldSpec need to overwrite `_format_regular_value` to implement custom behavior. Default is return what you get.
In the case of dates, we will always return a string in YYYYMMDD format.

This same mechanism will also be used for more sensible Integer support. 