### PR TITLE
support for negative integers

### DIFF
--- a/clkhash/field_formats.py
+++ b/clkhash/field_formats.py
@@ -557,7 +557,7 @@ class IntegerSpec(FieldSpec):
         """
         try:
             value = int(str_in, base=10)
-            return '{}'.format(value)
+            return str(value)
         except ValueError as e:
             msg = "Invalid integer. Read '{}'.".format(str_in)
             e_new = InvalidEntryError(msg)

--- a/clkhash/field_formats.py
+++ b/clkhash/field_formats.py
@@ -565,6 +565,7 @@ class IntegerSpec(FieldSpec):
             e_new = InvalidEntryError(msg)
             e_new.field_spec = self
             raise_from(e_new, e)
+            raise None  # otherwise mypy complains about missing return statement. It can't understand 'raise_from'
 
 
 class DateSpec(FieldSpec):

--- a/clkhash/field_formats.py
+++ b/clkhash/field_formats.py
@@ -563,7 +563,6 @@ class IntegerSpec(FieldSpec):
             e_new = InvalidEntryError(msg)
             e_new.field_spec = self
             raise_from(e_new, e)
-            raise None  # otherwise mypy complains about missing return statement. It can't understand 'raise_from'
 
 
 class DateSpec(FieldSpec):

--- a/clkhash/master-schemas/v1.json
+++ b/clkhash/master-schemas/v1.json
@@ -138,8 +138,8 @@
       "additionalProperties": false,
       "properties": {
         "type": {"enum": ["integer"]},
-        "minimum": {"type": "integer", "minimum": 0},
-        "maximum": {"type": "integer", "minimum": 1},
+        "minimum": {"type": "integer"},
+        "maximum": {"type": "integer"},
         "description": {"type": "string"}
       }
     },

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -286,8 +286,8 @@ numberFormat
 name        type                   optional description
 =========== =====================  ======== ===========
 type        string                 no       has to be "integer"
-minimum     integer                yes      positive integer describing the lower bound of the input values.
-maximum     integer                yes      positive integer describing the upper bound of the input values.
+minimum     integer                yes      integer describing the lower bound of the input values.
+maximum     integer                yes      integer describing the upper bound of the input values.
 description string                 yes      free text, ignored by clkhash.
 =========== =====================  ======== ===========
 


### PR DESCRIPTION
two things:
- we now support negative integers. (You can always look at the positive side of things...)
- we are more forgiving on the input integer strings. The problem was that there are several valid integer strings for on integer. E.g.: `' 1'`, `'+1'`, `'1 '` are all valid and parse-able strings for the integer `1`. We now first parse the integer string to an integer, then pass it on for hashing without white-spaces and `+`.