### PR TITLE
Omnibus PR for backports.py

### DIFF
--- a/tests/test_backports.py
+++ b/tests/test_backports.py
@@ -3,11 +3,13 @@
 from __future__ import unicode_literals
 
 from base64 import b64decode
+from datetime import datetime
 import io
 import itertools
 import unittest
 
-from clkhash.backports import int_from_bytes, re_compile_full, unicode_reader
+from clkhash.backports import (int_from_bytes, re_compile_full,
+                               unicode_reader, strftime)
 
 
 class TestIntBackports(unittest.TestCase):
@@ -91,3 +93,32 @@ class TestUnicodeReader(unittest.TestCase):
         reader = unicode_reader(f)
         read_data = list(reader)
         self.assertEqual(read_data, data)
+
+
+class TestStrftime(unittest.TestCase):
+    def test_recent_years(self):
+        self.assertEqual(
+            strftime(datetime(1995, 12, 23), '%Y/%m/%d'),
+            '1995/12/23')
+        self.assertEqual(
+            strftime(datetime(2004, 5, 1), '%d-%m-%Y'),
+            '01-05-2004')
+
+    def test_nonnative_years(self):
+        self.assertEqual(
+            strftime(datetime(1884, 2, 29), '%Y/%m/%d'),
+            '1884/02/29')
+        self.assertEqual(
+            strftime(datetime(1000, 1, 2), '%d-%m-%Y'),
+            '02-01-1000')
+
+    def test_short_years(self):
+        self.assertEqual(
+            strftime(datetime(942, 2, 12), '%Y/%m/%d'),
+            '0942/02/12')
+        self.assertEqual(
+            strftime(datetime(43, 1, 2), '%d-%m-%Y'),
+            '02-01-0043')
+        self.assertEqual(
+            strftime(datetime(1, 3, 16), '%d-%m-%Y'),
+            '16-03-0001')


### PR DESCRIPTION
Changes:

- Minor style (removing superfluous underscores, alignment, etc…)
- Minor typing (`raise_from` accepts `BaseException`, not `Exception`)
- Comment `strftime`
- Tests for `strftime`
- Fix bug where `strftime` fails for years < 1000