### PR TITLE
Remove unnecessary imports

### DIFF
--- a/tests/test_backports.py
+++ b/tests/test_backports.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 from base64 import b64decode
 from datetime import datetime
 import io
-import itertools
 import unittest
 
 from clkhash.backports import (int_from_bytes, re_compile_full,

--- a/tests/test_clk.py
+++ b/tests/test_clk.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-import json
 import io
 import unittest
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,6 +1,4 @@
 import unittest
-import random
-from bitarray import bitarray
 
 from clkhash.field_formats import FieldHashingProperties
 from clkhash.tokenizer import get_tokenizer, tokenize

--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -1,6 +1,5 @@
 import unittest
 
-from clkhash.backports import re_compile_full
 from clkhash.field_formats import (DateSpec, EnumSpec, FieldHashingProperties,
                                    IntegerSpec, StringSpec)
 from clkhash.validate_data import (EntryError, FormatError,


### PR DESCRIPTION
Fixes #101 by removing unused imports from the tests. I was unable to find any unused imports in the clkhash library itself.