### PR TITLE
Create two helper functions to wait for a run to complete

### DIFF
--- a/clkhash/backports.py
+++ b/clkhash/backports.py
@@ -104,8 +104,12 @@ unicode_reader = (_p2_unicode_reader  # Python 2 with hacky workarounds.
                   else csv.reader)  # Py3 with native Unicode support.
 
 if sys.version_info > (3, 2):
-    strftime = datetime.strftime
+    TimeoutError = globals()['__builtins__']['TimeoutError']
+else:
+    TimeoutError = Exception
 
+if sys.version_info > (3, 2):
+    strftime = datetime.strftime
 else:
     _YEAR_LEN = 4
 

--- a/clkhash/backports.py
+++ b/clkhash/backports.py
@@ -106,7 +106,7 @@ unicode_reader = (_p2_unicode_reader  # Python 2 with hacky workarounds.
 if sys.version_info > (3, 2):
     TimeoutError = globals()['__builtins__']['TimeoutError']
 else:
-    TimeoutError = Exception
+    TimeoutError = OSError
 
 if sys.version_info > (3, 2):
     strftime = datetime.strftime

--- a/clkhash/cli.py
+++ b/clkhash/cli.py
@@ -11,7 +11,7 @@ import click
 import clkhash
 from clkhash import benchmark as bench, clk, randomnames, validate_data
 from clkhash.rest_client import project_upload_clks, run_get_result_text, run_get_status, project_create, run_create, \
-    server_get_status, ServiceError, format_run_status
+    server_get_status, ServiceError, format_run_status, watch_run_status
 
 DEFAULT_SERVICE_URL = 'https://es.data61.xyz'
 
@@ -249,9 +249,7 @@ def results(project, apikey, run, watch, server, output):
     status = run_get_status(server, project, run, apikey)
     log(format_run_status(status))
     if watch:
-        while status['state'] not in {'error', 'completed'}:
-            time.sleep(1)
-            status = run_get_status(server, project, run, apikey)
+        for status in watch_run_status(server, project, run, apikey, 24*60*60):
             log(format_run_status(status))
 
     if status['state'] == 'completed':

--- a/clkhash/rest_client.py
+++ b/clkhash/rest_client.py
@@ -2,6 +2,7 @@ import time
 
 import requests
 import clkhash
+from clkhash.backports import TimeoutError
 import logging
 
 logger = logging.getLogger(__name__)
@@ -21,12 +22,6 @@ class ServiceError(Exception):
 class RateLimitedClient(ServiceError):
     """Exception indicating client is asking for updates too frequently.
     """
-
-
-try:
-    TimeoutError
-except NameError:
-    TimeoutError = ValueError
 
 
 def _handle_json_response(response, failure_message, expected_status_code=200):

--- a/clkhash/rest_client.py
+++ b/clkhash/rest_client.py
@@ -1,3 +1,5 @@
+import time
+
 import requests
 import clkhash
 import logging
@@ -103,6 +105,26 @@ def run_get_status(server, project, run, apikey):
         headers={"Authorization": apikey}
     )
     return _handle_json_response(response, "Run Status Error", 200)
+
+
+def wait_for_run(server, project, run, apikey, timeout=300):
+    start_time = time.time()
+    status = run_get_status(server, project, run, apikey)
+    while status['state'] not in {'error', 'completed'} and time.time() - start_time < timeout:
+        time.sleep(1)
+        status = run_get_status(server, project, run, apikey)
+    return status
+
+
+def watch_run_status(server, project, run, apikey, timeout=300):
+    start_time = time.time()
+    status = run_get_status(server, project, run, apikey)
+    while status['state'] not in {'error', 'completed'} and time.time() - start_time < timeout:
+        time.sleep(1)
+        status = run_get_status(server, project, run, apikey)
+        yield status
+
+    raise StopIteration
 
 
 def run_get_result_text(server, project, run, apikey):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -519,7 +519,7 @@ class TestCliInteractionWithService(CLITestHelper):
         self.assertGreaterEqual(number_in_common / self.SAMPLES, 0.4)
         self.assertLessEqual(number_in_common / self.SAMPLES, 0.6)
 
-        # # Get results from first DP
+        # Get results from first DP
         alice_res = self.run_command_load_json_output(
             [
                 'results',
@@ -532,3 +532,19 @@ class TestCliInteractionWithService(CLITestHelper):
 
         self.assertIn('permutation', alice_res)
         self.assertIn('rows', alice_res)
+
+        # Get results from second DP
+        bob_res = self.run_command_load_json_output(
+            [
+                'results',
+                '--server', self.url,
+                '--project', project['project_id'],
+                '--run', run['run_id'],
+                '--apikey', bob_upload['receipt_token'],
+                '--watch'
+            ]
+        )
+
+        self.assertIn('permutation', bob_res)
+        self.assertIn('rows', bob_res)
+

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -68,8 +68,7 @@ class TestRestClientInteractionWithService(unittest.TestCase):
         assert 'state' in status1
         assert 'stages' in status1
         print(rest_client.format_run_status(status1))
-        time.sleep(2)
-        status2 = rest_client.run_get_status(self.url, p_id, r_id, p['result_token'])
+        status2 = rest_client.wait_for_run(self.url, p_id, r_id, p['result_token'], 30)
         assert status2['state'] == 'completed'
         coord_result_raw = rest_client.run_get_result_text(self.url, p_id, r_id, p['result_token'])
         coord_result = json.loads(coord_result_raw)

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -10,13 +10,8 @@ import clkhash
 from clkhash.clk import generate_clk_from_csv
 from clkhash import rest_client
 from clkhash.rest_client import ServiceError
+from clkhash.backports import TimeoutError
 from tests import SIMPLE_SCHEMA_PATH, SAMPLE_DATA_SCHEMA_PATH, SAMPLE_DATA_PATH_1, SAMPLE_DATA_PATH_2
-
-
-try:
-    TimeoutError
-except NameError:
-    TimeoutError = ValueError
 
 
 @unittest.skipUnless("TEST_ENTITY_SERVICE" in os.environ,


### PR DESCRIPTION
Extra feature for the rest_client - wait for run completion.

One function yields status updates, one just waits until the very end (or until a timeout expires).

~I could change the generator to only give updates that have "changed" - not just every second. But interested in your thoughts.~  Now implemented.

