### PR TITLE
Add support for dependenies.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is as described by Rainer Schnell, Tobias Bachteler, and Jörg Reiher in
 [![codecov](https://codecov.io/gh/n1analytics/clkhash/branch/master/graph/badge.svg)](https://codecov.io/gh/n1analytics/clkhash)
 [![Documentation Status](https://readthedocs.org/projects/clkhash/badge/?version=latest)](http://clkhash.readthedocs.io/en/latest/?badge=latest)
 [![Build Status](https://travis-ci.org/n1analytics/clkhash.svg?branch=master)](https://travis-ci.org/n1analytics/clkhash)
+[![Requirements Status](https://requires.io/github/n1analytics/clkhash/requirements.svg?branch=master)](https://requires.io/github/n1analytics/clkhash/requirements/?branch=master)
 
 ## Installation
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,0 +1,6 @@
+version: 2
+dependencies:
+- type: python
+  path: requirements.txt
+- type: python
+  path: docs/doc-requirements.txt

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -2,5 +2,13 @@ version: 2
 dependencies:
 - type: python
   path: requirements.txt
+  settings:
+    related_pr_behavior: close
+    github_labels:
+    - dependencies
 - type: python
   path: docs/doc-requirements.txt
+  settings:
+    related_pr_behavior: close
+    github_labels:
+    - dependencies


### PR DESCRIPTION
By adding this config file and adding the GitHub application for https://app.dependencies.io/projects/github/n1analytics/clkhash we should get notified when our library dependencies have updates.

This is to address https://github.com/n1analytics/clkhash/issues/97