### PR TITLE
Bugfix in restclient - generators should terminate with return

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-# After changing this file, check it on:
-#   http://lint.travis-ci.org/
 language: python
 sudo: false
+dist: xenial
 
 python:
   - '2.7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.11.3
+
+- Bugfix in restclient to support Python 3.7
+- Bugfix in progress messages.
+- Dependency updates.
+
 ## 0.11.2
 
 - Updates to dependencies.

--- a/clkhash/rest_client.py
+++ b/clkhash/rest_client.py
@@ -162,7 +162,7 @@ def watch_run_status(server, project, run, apikey, timeout=None, update_period=1
         if status['state'] in {'error', 'completed'}:
             # No point continuing as run has entered a terminal state
             yield status
-            raise StopIteration
+            return
 
         if old_status != status:
             yield status

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with codecs.open('README.md', 'r', 'utf-8') as f:
 
 setup(
     name="clkhash",
-    version='0.11.2',
+    version='0.11.3',
     description='Hash utility to create Cryptographic Linkage Keys',
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36
+envlist = py27, py35, py36, py37
 
 [testenv]
 deps =


### PR DESCRIPTION
Opps I introduced a bug which raises a runtime error in the most recent pythons. The fact this isn't picked up in our tests is captured in #177

Source:
> Finally, the proposal also clears up the confusion about how to terminate a generator: the proper way is return, not raise StopIteration.
https://www.python.org/dev/peps/pep-0479/