### PR TITLE
Travis to run rest_client tests on python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ matrix:
     - python: 'pypy3'
 
   include:
+    - python: '3.7-dev'
+      env:
+        - TEST_ENTITY_SERVICE=https://testing.es.data61.xyz
+        - MYPY_TYPING=1
+        - INCLUDE_CLI=1
     - python: '3.6'
       env:
         - TEST_ENTITY_SERVICE=https://testing.es.data61.xyz


### PR DESCRIPTION
Turns out the `TEST_ENTITY_SERVICE` env var is required to call the external service. Now enabled for Python 3.7

Closes #177 
