### PR TITLE
Cli describe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ sudo: false
 dist: xenial
 
 python:
-  - '2.7'
   - '3.5'
-  - '3.6'
-  - '3.7-dev'
   - 'nightly'
   - 'pypy'
   - 'pypy3'

--- a/clkhash/__init__.py
+++ b/clkhash/__init__.py
@@ -1,6 +1,6 @@
 import pkg_resources
 
-from . import bloomfilter, field_formats, key_derivation, schema, randomnames
+from . import bloomfilter, field_formats, key_derivation, schema, randomnames, describe
 
 try:
     __version__ = pkg_resources.get_distribution('clkhash').version

--- a/clkhash/backports.py
+++ b/clkhash/backports.py
@@ -104,7 +104,10 @@ unicode_reader = (_p2_unicode_reader  # Python 2 with hacky workarounds.
                   else csv.reader)  # Py3 with native Unicode support.
 
 if sys.version_info > (3, 2):
-    TimeoutError = globals()['__builtins__']['TimeoutError']
+    try:
+        TimeoutError = globals()['__builtins__']['TimeoutError']
+    except:
+        pass    # pypy3 raises TypeError: 'module' object is not subscriptable
 else:
     TimeoutError = OSError
 

--- a/clkhash/bloomfilter.py
+++ b/clkhash/bloomfilter.py
@@ -352,3 +352,13 @@ def serialize_bitarray(ba):
 
     """
     return base64.b64encode(ba.tobytes()).decode('utf8')
+
+# TODO: I think this must already exist in anonlink - maybe that implelemtation should be moved here
+def deserialize_bitarray(ser):
+    # type: str -> (bitarray)
+    """Deserialize a base 64 encoded string to a bitarray (bloomfilter)
+    
+    """
+    ba = bitarray()   # TODO: Is endianess used consistently?
+    ba.frombytes(base64.b64decode(ser.encode(encoding='UTF-8', errors='strict')))
+    return ba

--- a/clkhash/bloomfilter.py
+++ b/clkhash/bloomfilter.py
@@ -355,7 +355,7 @@ def serialize_bitarray(ba):
 
 # TODO: I think this must already exist in anonlink - maybe that implelemtation should be moved here
 def deserialize_bitarray(ser):
-    # type: str -> (bitarray)
+    # type: (str) -> bitarray
     """Deserialize a base 64 encoded string to a bitarray (bloomfilter)
     
     """

--- a/clkhash/bloomfilter.py
+++ b/clkhash/bloomfilter.py
@@ -345,20 +345,3 @@ def stream_bloom_filters(dataset,  # type: Iterable[Sequence[Text]]
                                 keys, hash_properties)
             for s in dataset)
 
-
-def serialize_bitarray(ba):
-    # type: (bitarray) -> str
-    """Serialize a bitarray (bloomfilter)
-
-    """
-    return base64.b64encode(ba.tobytes()).decode('utf8')
-
-# TODO: I think this must already exist in anonlink - maybe that implelemtation should be moved here
-def deserialize_bitarray(ser):
-    # type: (str) -> bitarray
-    """Deserialize a base 64 encoded string to a bitarray (bloomfilter)
-    
-    """
-    ba = bitarray()   # TODO: Is endianess used consistently?
-    ba.frombytes(base64.b64decode(ser.encode(encoding='UTF-8', errors='strict')))
-    return ba

--- a/clkhash/cli.py
+++ b/clkhash/cli.py
@@ -42,7 +42,7 @@ def cli():
 
 
 @cli.command('hash', short_help="generate hashes from local PII data")
-@click.argument('input', type=click.File('r'))
+@click.argument('pii_csv', type=click.File('r'))
 @click.argument('keys', nargs=2, type=click.Tuple([str, str]))
 @click.argument('schema', type=click.File('r', lazy=True))
 @click.argument('output', type=click.File('w'))
@@ -50,10 +50,10 @@ def cli():
 @click.option('--no-header', default=False, is_flag=True, help="Don't skip the first row")
 @click.option('--check-header', default=True, type=bool, help="If true, check the header against the schema")
 @click.option('--validate', default=True, type=bool, help="If true, validate the entries against the schema")
-def hash(input, keys, schema, output, quiet, no_header, check_header, validate):
+def hash(pii_csv, keys, schema, output, quiet, no_header, check_header, validate):
     """Process data to create CLKs
 
-    Given a file containing csv data as INPUT, and a json
+    Given a file containing csv data as PII_CSV, and a json
     document defining the expected schema, verify the schema, then
     hash the data to create CLKs writing to OUTPUT. Note the CSV
     file should contain a header row - however this row is not used
@@ -61,7 +61,7 @@ def hash(input, keys, schema, output, quiet, no_header, check_header, validate):
 
     It is important that the keys are only known by the two data providers. Two words should be provided. For example:
 
-    $clkutil hash input.txt horse staple output.txt
+    $clkutil hash pii.csv horse staple output.txt
 
     Use "-" to output to stdout.
     """
@@ -75,7 +75,7 @@ def hash(input, keys, schema, output, quiet, no_header, check_header, validate):
 
     try:
         clk_data = clk.generate_clk_from_csv(
-            input, keys, schema_object,
+            pii_csv, keys, schema_object,
             validate=validate,
             header=header,
             progress_bar=not quiet)
@@ -200,27 +200,27 @@ def create(server, name, project, apikey, output, threshold, verbose):
 
 
 @cli.command('upload', short_help='upload hashes to entity service')
-@click.argument('input', type=click.File('r'))
+@click.argument('clk_json', type=click.File('r'))
 @click.option('--project', help='Project identifier')
 @click.option('--apikey', help='Authentication API key for the server.')
 @click.option('--server', type=str, default=DEFAULT_SERVICE_URL, help="Server address including protocol")
 @click.option('-o', '--output', type=click.File('w'), default='-')
 @click.option('-v', '--verbose', default=False, is_flag=True, help="Script is more talkative")
-def upload(input, project, apikey, server, output, verbose):
+def upload(clk_json, project, apikey, server, output, verbose):
     """Upload CLK data to entity matching server.
 
-    Given a json file containing hashed clk data as INPUT, upload to
+    Given a json file containing hashed clk data as CLK_JSON, upload to
     the entity resolution service.
 
     Use "-" to read from stdin.
     """
     if verbose:
-        log("Uploading CLK data from {}".format(input.name))
+        log("Uploading CLK data from {}".format(clk_json.name))
         log("To Entity Matching Server: {}".format(server))
         log("Project ID: {}".format(project))
         log("Uploading CLK data to the server")
 
-    response = project_upload_clks(server, project, apikey, input)
+    response = project_upload_clks(server, project, apikey, clk_json)
 
     if verbose:
         log(response)
@@ -271,9 +271,9 @@ def benchmark():
 
 
 @cli.command('describe', short_help='show distribution of clk popcounts')
-@click.argument('input', type=click.File('r'))
-def describe(input):
-    descr.plot(input)
+@click.argument('clk_json', type=click.File('r'))
+def describe(clk_json):
+    descr.plot(clk_json)
 
 
 @cli.command('generate', short_help='generate random pii data for testing')

--- a/clkhash/cli.py
+++ b/clkhash/cli.py
@@ -9,7 +9,7 @@ import time
 import click
 
 import clkhash
-from clkhash import benchmark as bench, clk, randomnames, validate_data
+from clkhash import benchmark as bench, clk, randomnames, validate_data, describe as descr
 from clkhash.rest_client import project_upload_clks, run_get_result_text, run_get_status, project_create, run_create, \
     server_get_status, ServiceError, format_run_status, watch_run_status
 
@@ -268,6 +268,12 @@ def results(project, apikey, run, watch, server, output):
 @cli.command('benchmark', short_help='carry out a local benchmark')
 def benchmark():
     bench.compute_hash_speed(10000)
+
+
+@cli.command('describe', short_help='show distribution of clk popcounts')
+@click.argument('input', type=click.File('r'))
+def describe(input):
+    descr.plot(input)
 
 
 @cli.command('generate', short_help='generate random pii data for testing')

--- a/clkhash/cli.py
+++ b/clkhash/cli.py
@@ -49,17 +49,16 @@ def cli():
 @click.option('--no-header', default=False, is_flag=True, help="Don't skip the first row")
 @click.option('--check-header', default=True, type=bool, help="If true, check the header against the schema")
 @click.option('--validate', default=True, type=bool, help="If true, validate the entries against the schema")
-def hash(pii_csv, keys, schema, output, quiet, no_header, check_header, validate):
+def hash(pii_csv, keys, schema, clk_json, quiet, no_header, check_header, validate):
     """Process data to create CLKs
 
     Given a file containing CSV data as PII_CSV, and a JSON
     document defining the expected schema, verify the schema, then
-    hash the data to create CLKs writing them as JSON to CLK_JSON.
-    Note the CSV file should contain a header row - however this
-    row is not used by this tool.
+    hash the data to create CLKs writing them as JSON to CLK_JSON. Note the CSV
+    file should contain a header row - however this row is not used
+    by this tool.
 
-    It is important that the keys are only known by the two data providers.
-    Two words should be provided. For example:
+    It is important that the keys are only known by the two data providers. Two words should be provided. For example:
 
     $clkutil hash pii.csv horse staple pii-schema.json clk.json
 
@@ -84,9 +83,9 @@ def hash(pii_csv, keys, schema, output, quiet, no_header, check_header, validate
         log(msg)
         log('Hashing failed.')
     else:
-        json.dump({'clks': clk_data}, output)
-        if hasattr(output, 'name'):
-            log("CLK data written to {}".format(output.name))
+        json.dump({'clks': clk_data}, clk_json)
+        if hasattr(clk_json, 'name'):
+            log("CLK data written to {}".format(clk_json.name))
 
 
 @cli.command('status', short_help='Get status of entity service')

--- a/clkhash/cli.py
+++ b/clkhash/cli.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import json
 import os
 import shutil
-import time
 
 import click
 

--- a/clkhash/cli.py
+++ b/clkhash/cli.py
@@ -44,7 +44,7 @@ def cli():
 @click.argument('pii_csv', type=click.File('r'))
 @click.argument('keys', nargs=2, type=click.Tuple([str, str]))
 @click.argument('schema', type=click.File('r', lazy=True))
-@click.argument('output', type=click.File('w'))
+@click.argument('clk_json', type=click.File('w'))
 @click.option('-q', '--quiet', default=False, is_flag=True, help="Quiet any progress messaging")
 @click.option('--no-header', default=False, is_flag=True, help="Don't skip the first row")
 @click.option('--check-header', default=True, type=bool, help="If true, check the header against the schema")
@@ -52,17 +52,18 @@ def cli():
 def hash(pii_csv, keys, schema, output, quiet, no_header, check_header, validate):
     """Process data to create CLKs
 
-    Given a file containing csv data as PII_CSV, and a json
+    Given a file containing CSV data as PII_CSV, and a JSON
     document defining the expected schema, verify the schema, then
-    hash the data to create CLKs writing to OUTPUT. Note the CSV
-    file should contain a header row - however this row is not used
-    by this tool.
+    hash the data to create CLKs writing them as JSON to CLK_JSON.
+    Note the CSV file should contain a header row - however this
+    row is not used by this tool.
 
-    It is important that the keys are only known by the two data providers. Two words should be provided. For example:
+    It is important that the keys are only known by the two data providers.
+    Two words should be provided. For example:
 
-    $clkutil hash pii.csv horse staple output.txt
+    $clkutil hash pii.csv horse staple pii-schema.json clk.json
 
-    Use "-" to output to stdout.
+    Use "-" for CLK_JSON to write JSON to stdout.
     """
 
     schema_object = clkhash.schema.Schema.from_json_file(schema_file=schema)

--- a/clkhash/clk.py
+++ b/clkhash/clk.py
@@ -5,16 +5,15 @@ Generate CLK from data.
 import concurrent.futures
 import logging
 import time
-from typing import (AnyStr, Callable, cast, Iterable, List, Optional,
-                    Sequence, TextIO, Tuple, TypeVar, Union)
+from typing import (Callable, cast, Sequence, TypeVar)
 
 from future.builtins import range
 from tqdm import tqdm
 
 from clkhash.backports import unicode_reader
-from clkhash.bloomfilter import stream_bloom_filters, serialize_bitarray
+from clkhash.bloomfilter import stream_bloom_filters
+from clkhash.serialization import serialize_bitarray
 from clkhash.key_derivation import generate_key_lists
-from clkhash.schema import Schema
 from clkhash.stats import OnlineMeanVariance
 from clkhash.validate_data import (validate_entries, validate_header,
                                    validate_row_lengths)

--- a/clkhash/clk.py
+++ b/clkhash/clk.py
@@ -5,8 +5,8 @@ Generate CLK from data.
 import concurrent.futures
 import logging
 import time
-from typing import (Callable, cast, Sequence, TypeVar)
-
+from typing import (AnyStr, Callable, cast, Iterable, List, Optional,
+                    Sequence, TextIO, Tuple, TypeVar, Union)
 from future.builtins import range
 from tqdm import tqdm
 
@@ -14,6 +14,7 @@ from clkhash.backports import unicode_reader
 from clkhash.bloomfilter import stream_bloom_filters
 from clkhash.serialization import serialize_bitarray
 from clkhash.key_derivation import generate_key_lists
+from clkhash.schema import Schema
 from clkhash.stats import OnlineMeanVariance
 from clkhash.validate_data import (validate_entries, validate_header,
                                    validate_row_lengths)

--- a/clkhash/describe.py
+++ b/clkhash/describe.py
@@ -5,9 +5,11 @@ from clkhash.backports import raise_from
 from bashplotlib.histogram import plot_hist
 from clkhash.serialization import deserialize_bitarray
 
+
 class DescribeError(Exception):
     """ The user provided CLK JSON is invalid.
     """
+
 
 def plot(clk_json):
     try:
@@ -19,8 +21,9 @@ def plot(clk_json):
         msg = 'The input is not a valid JSON file.'
         raise_from(DescribeError(msg), e)
         
-    
-    popcounts = [ deserialize_bitarray(clk).count() for clk in clks ]
+    if len(clks) == 0:
+        msg = 'No clks found'
+        raise DescribeError(msg)
+
+    popcounts = [deserialize_bitarray(clk).count() for clk in clks]
     plot_hist(popcounts, bincount=60, title='popcounts', xlab=True, showSummary=True)
-        
-    

--- a/clkhash/describe.py
+++ b/clkhash/describe.py
@@ -10,10 +10,10 @@ class DescribeError(Exception):
     """ The user provided CLK JSON is invalid.
     """
 
-def plot(input):
+def plot(clk_json):
     try:
         # data was writen with: json.dump({'clks': clk_data}, output); so ...
-        clks = json.load(input)['clks']
+        clks = json.load(clk_json)['clks']
     except ValueError as e:  # In Python 3 we can be more specific
         # with json.decoder.JSONDecodeError,
         # but that doesn't exist in Python 2.

--- a/clkhash/describe.py
+++ b/clkhash/describe.py
@@ -21,6 +21,6 @@ def plot(clk_json):
         
     
     popcounts = [ deserialize_bitarray(clk).count() for clk in clks ]
-    plot_hist(popcounts, bincount=60, xlab=True, showSummary=True)
+    plot_hist(popcounts, bincount=60, title='popcounts', xlab=True, showSummary=True)
         
     

--- a/clkhash/describe.py
+++ b/clkhash/describe.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import click
 import json
 from clkhash.backports import raise_from
 from bashplotlib.histogram import plot_hist
-from clkhash.bloomfilter import deserialize_bitarray
+from clkhash.serialization import deserialize_bitarray
 
 class DescribeError(Exception):
     """ The user provided CLK JSON is invalid.

--- a/clkhash/describe.py
+++ b/clkhash/describe.py
@@ -22,6 +22,6 @@ def plot(input):
         
     
     popcounts = [ deserialize_bitarray(clk).count() for clk in clks ]
-    plot_hist(popcounts, title='popcounts', xlab=True)
+    plot_hist(popcounts, bincount=60, xlab=True, showSummary=True)
         
     

--- a/clkhash/describe.py
+++ b/clkhash/describe.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+import click
+import json
+from clkhash.backports import raise_from
+from bashplotlib.histogram import plot_hist
+from clkhash.bloomfilter import deserialize_bitarray
+
+class DescribeError(Exception):
+    """ The user provided CLK JSON is invalid.
+    """
+
+def plot(input):
+    try:
+        # data was writen with: json.dump({'clks': clk_data}, output); so ...
+        clks = json.load(input)['clks']
+    except ValueError as e:  # In Python 3 we can be more specific
+        # with json.decoder.JSONDecodeError,
+        # but that doesn't exist in Python 2.
+        msg = 'The input is not a valid JSON file.'
+        raise_from(DescribeError(msg), e)
+        
+    
+    popcounts = [ deserialize_bitarray(clk).count() for clk in clks ]
+    plot_hist(popcounts, title='popcounts', xlab=True)
+        
+    

--- a/clkhash/serialization.py
+++ b/clkhash/serialization.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+"""
+Serialize bitarray to/from base64 utf-8 encoded string
+"""
+
+import base64
+from bitarray import bitarray
+
+
+def serialize_bitarray(ba):
+    # type: (bitarray) -> str
+    """Serialize a bitarray (bloomfilter)
+
+    """
+    return base64.b64encode(ba.tobytes()).decode('utf8')
+
+# TODO: I think this must already exist in anonlink - maybe that implelemtation should be moved here
+def deserialize_bitarray(ser):
+    # type: (str) -> bitarray
+    """Deserialize a base 64 encoded string to a bitarray (bloomfilter)
+    
+    """
+    ba = bitarray()   # TODO: Is endianess used consistently?
+    ba.frombytes(base64.b64decode(ser.encode(encoding='UTF-8', errors='strict')))
+    return ba

--- a/clkhash/serialization.py
+++ b/clkhash/serialization.py
@@ -15,12 +15,11 @@ def serialize_bitarray(ba):
     """
     return base64.b64encode(ba.tobytes()).decode('utf8')
 
-# TODO: I think this must already exist in anonlink - maybe that implelemtation should be moved here
 def deserialize_bitarray(ser):
     # type: (str) -> bitarray
     """Deserialize a base 64 encoded string to a bitarray (bloomfilter)
     
     """
-    ba = bitarray()   # TODO: Is endianess used consistently?
+    ba = bitarray()
     ba.frombytes(base64.b64decode(ser.encode(encoding='UTF-8', errors='strict')))
     return ba

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ requirements = [
         "jsonschema>=2.6",
         "requests>=2.18",
         "tqdm>=4.24",
-        "typing>=3.6; python_version < '3.5'"  # Backport from Py3.5
+        "typing>=3.6; python_version < '3.5'",  # Backport from Py3.5
+	"bashplotlib>=0.6.5"
     ]
 
 with codecs.open('README.md', 'r', 'utf-8') as f:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
         "requests>=2.18",
         "tqdm>=4.24",
         "typing>=3.6; python_version < '3.5'",  # Backport from Py3.5
-	"bashplotlib>=0.6.5"
+        "bashplotlib>=0.6.5"
     ]
 
 with codecs.open('README.md', 'r', 'utf-8') as f:

--- a/tests/test_bloomfilter.py
+++ b/tests/test_bloomfilter.py
@@ -4,10 +4,13 @@ import random
 import unittest
 
 from future.builtins import range
+from bitarray import bitarray
+from math import ceil
 
 from clkhash.bloomfilter import (
     blake_encode_ngrams, double_hash_encode_ngrams,
-    double_hash_encode_ngrams_non_singular, NgramEncodings)
+    double_hash_encode_ngrams_non_singular, NgramEncodings,
+    serialize_bitarray, deserialize_bitarray)
 from clkhash.schema import GlobalHashingProperties
 
 
@@ -94,3 +97,22 @@ class TestNgramEncodings(unittest.TestCase):
                 ValueError,
                 msg='Expected ValueError on invalid encoding.'):
             NgramEncodings.from_properties(properties)
+
+def randomBitarray(numBytes):
+    ba = bitarray()
+    ba.frombytes(random.getrandbits(numBytes * 8).to_bytes(numBytes, byteorder='big'))
+    return ba
+    
+class TestSerialization(unittest.TestCase):
+    def test_ser_deser_inverse(self):
+        numBytes = 128
+        ba = randomBitarray(numBytes)
+        
+        ser = serialize_bitarray(ba)
+        # https://stackoverflow.com/questions/4715415/base64-what-is-the-worst-possible-increase-in-space-usage
+        self.assertEqual(len(ser), ceil(numBytes/3) * 4)
+
+        des = deserialize_bitarray(ser)
+        self.assertEqual(ba, des)
+
+

--- a/tests/test_bloomfilter.py
+++ b/tests/test_bloomfilter.py
@@ -9,8 +9,7 @@ from math import ceil
 
 from clkhash.bloomfilter import (
     blake_encode_ngrams, double_hash_encode_ngrams,
-    double_hash_encode_ngrams_non_singular, NgramEncodings,
-    serialize_bitarray, deserialize_bitarray)
+    double_hash_encode_ngrams_non_singular, NgramEncodings)
 from clkhash.schema import GlobalHashingProperties
 
 
@@ -102,17 +101,3 @@ def randomBitarray(numBytes):
     ba = bitarray()
     ba.frombytes(random.getrandbits(numBytes * 8).to_bytes(numBytes, byteorder='big'))
     return ba
-    
-class TestSerialization(unittest.TestCase):
-    def test_ser_deser_inverse(self):
-        numBytes = 128
-        ba = randomBitarray(numBytes)
-        
-        ser = serialize_bitarray(ba)
-        # https://stackoverflow.com/questions/4715415/base64-what-is-the-worst-possible-increase-in-space-usage
-        self.assertEqual(len(ser), ceil(numBytes/3) * 4)
-
-        des = deserialize_bitarray(ser)
-        self.assertEqual(ba, des)
-
-

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -9,25 +9,42 @@ except ImportError:
     
 from clkhash import randomnames
 from clkhash.clk import generate_clks
-from clkhash.describe import plot
-    
+from clkhash.describe import plot, DescribeError
+
+
 class TestDescribe(unittest.TestCase):
+
+    def setUp(self):
+        # capture stdout
+        self.original_stdout = sys.stdout
+        self.temp_std_out = StringIO()
+        sys.stdout = self.temp_std_out
+
+    def tearDown(self):
+        sys.stdout = self.original_stdout  # restore stdout for following tests
+
     def test_describe(self):
         size = 1000
         pii_data = randomnames.NameList(size)
 
         clks = generate_clks(pii_data.names, pii_data.SCHEMA, ('key1', 'key2'), validate=True)
         json_clks = json.dumps({'clks': clks})
-        
-        # capture stdout
-        orig = sys.stdout
-        out = StringIO()
-        sys.stdout = out
-        
-        plot(StringIO(json_clks))   # clkutil describe
-        sys.stdout = orig           # restore stdout for following tests
-        self.assertTrue(' observations: {} '.format(size) in out.getvalue())
-        # print('out = {}'.format(out.getvalue()))
 
-if __name__ == "__main__":
-    unittest.main()
+        plot(StringIO(json_clks))   # clkutil describe
+
+        assert ' observations: {} '.format(size) in self.temp_std_out.getvalue()
+
+    def test_describe_no_clks(self):
+        json_clks = json.dumps({'clks': []})
+        with self.assertRaises(DescribeError) as e:
+            plot(StringIO(json_clks))   # clkutil describe
+
+        assert 'No clks found' in e.exception.args[0]
+
+    def test_describe_non_json_clks(self):
+        not_json_clks = 'notclks and [not](even) json'
+
+        with self.assertRaises(DescribeError) as e:
+            plot(StringIO(not_json_clks))   # clkutil describe <file>
+
+        assert 'not a valid JSON' in e.exception.args[0]

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -1,0 +1,30 @@
+import unittest
+import json
+import sys
+
+from clkhash import randomnames
+from clkhash.clk import generate_clks
+from clkhash.describe import plot
+
+try:
+    from io import StringIO        # Python 3
+except ImportError:
+    from StringIO import StringIO  # Python 2
+    
+class TestDescribe(unittest.TestCase):
+    def test_describe(self):
+        size = 1000
+        pii_data = randomnames.NameList(size)
+
+        clks = generate_clks(pii_data.names, pii_data.SCHEMA, ('key1', 'key2'), validate=True)
+        json_clks = json.dumps({'clks': clks})
+        
+        # capture stdout
+        orig = sys.stdout
+        out = StringIO()
+        sys.stdout = out
+        
+        plot(StringIO(json_clks))   # clkutil describe
+        sys.stdout = orig           # restore stdout for following tests
+        self.assertTrue(' observations: {} '.format(size) in out.getvalue())
+        # print('out = {}'.format(out.getvalue()))

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -2,14 +2,14 @@ import unittest
 import json
 import sys
 
+try:
+    from StringIO import StringIO  # Python 2
+except ImportError:
+    from io import StringIO        # Python 3
+    
 from clkhash import randomnames
 from clkhash.clk import generate_clks
 from clkhash.describe import plot
-
-try:
-    from io import StringIO        # Python 3
-except ImportError:
-    from StringIO import StringIO  # Python 2
     
 class TestDescribe(unittest.TestCase):
     def test_describe(self):
@@ -28,3 +28,6 @@ class TestDescribe(unittest.TestCase):
         sys.stdout = orig           # restore stdout for following tests
         self.assertTrue(' observations: {} '.format(size) in out.getvalue())
         # print('out = {}'.format(out.getvalue()))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -19,6 +19,13 @@ class TestSchemaValidation(unittest.TestCase):
         with open(_test_data_file_path('good-schema-v1.json')) as f:
             schema.Schema.from_json_file(f)
 
+    def test_good_schema_repr(self):
+        with open(_test_data_file_path('good-schema-v1.json')) as f:
+            s = schema.Schema.from_json_file(f)
+        schema_repr = repr(s)
+        assert "v1" in schema_repr
+        assert "11 fields" in schema_repr
+
     def test_invalid_schema(self):
         # This schema is not valid (missing encoding in its feature).
         with open(_test_data_file_path('bad-schema-v1.json')) as f:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -18,7 +18,7 @@ class TestSerialization(unittest.TestCase):
         
         ser = serialize_bitarray(ba)
         # https://stackoverflow.com/questions/4715415/base64-what-is-the-worst-possible-increase-in-space-usage
-        self.assertEqual(len(ser), ceil(numBytes/3) * 4)
+        self.assertEqual(len(ser), ceil(numBytes/3.0) * 4)
 
         des = deserialize_bitarray(ser)
         self.assertEqual(ba, des)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,4 +1,4 @@
-import random
+import os
 import unittest
 
 from bitarray import bitarray
@@ -7,9 +7,9 @@ from math import ceil
 from clkhash.serialization import serialize_bitarray, deserialize_bitarray
 
 def randomBitarray(numBytes):
-    ba = bitarray()
-    ba.frombytes(random.getrandbits(numBytes * 8).to_bytes(numBytes, byteorder='big'))
-    return ba
+    a = bitarray()
+    a.frombytes(os.urandom(numBytes))
+    return a
     
 class TestSerialization(unittest.TestCase):
     def test_ser_deser_inverse(self):
@@ -23,4 +23,5 @@ class TestSerialization(unittest.TestCase):
         des = deserialize_bitarray(ser)
         self.assertEqual(ba, des)
 
-
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,26 @@
+import random
+import unittest
+
+from bitarray import bitarray
+from math import ceil
+
+from clkhash.serialization import serialize_bitarray, deserialize_bitarray
+
+def randomBitarray(numBytes):
+    ba = bitarray()
+    ba.frombytes(random.getrandbits(numBytes * 8).to_bytes(numBytes, byteorder='big'))
+    return ba
+    
+class TestSerialization(unittest.TestCase):
+    def test_ser_deser_inverse(self):
+        numBytes = 128
+        ba = randomBitarray(numBytes)
+        
+        ser = serialize_bitarray(ba)
+        # https://stackoverflow.com/questions/4715415/base64-what-is-the-worst-possible-increase-in-space-usage
+        self.assertEqual(len(ser), ceil(numBytes/3) * 4)
+
+        des = deserialize_bitarray(ser)
+        self.assertEqual(ba, des)
+
+


### PR DESCRIPTION
Questions in # TODO: comments.

Works: python{,3} -m clkhash.cli describe fake-clk.json

Works: python3 -m unittest tests/test_bloomfilter.py
but with python (2):
  ...
  File "/usr/lib/python2.7/unittest/loader.py", line 91, in loadTestsFromName
    module = __import__('.'.join(parts_copy))
ImportError: Import by filename is not supported.

Type checker not yet run.

All improvements/comments welcome.
